### PR TITLE
Work around Dockerhub rate limits when building image in Quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM golang:1.15 AS build
+#
+# The golang:1.15 image is a copy of docker.io/library/golang:1.15 hosted in Quay to work around rate limits to
+# Dockerhub:
+#
+# > docker pull golang:1.15
+# > docker tag golang:1.15 quay.io/redhat-certification/golang:1.15
+# > docker push quay.io/redhat-certification/golang:1.15
+#
+# To upgrade Go, then a new image should be pushed to Quay and updated below.
+#
+FROM quay.io/redhat-certification/golang:1.15 as build
 
 WORKDIR /tmp/src
 


### PR DESCRIPTION
Use a copy of docker.io/library/golang:1.15 in Quay to work around rate limits building the image