### PR TITLE
add reports including chart.yaml content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 /out/
+**/reports/

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -28,6 +28,10 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
 )
 
+const (
+	Version = "1.0.0"
+)
+
 func init() {
 	allChecks = chartverifier.DefaultRegistry().AllChecks()
 }
@@ -96,6 +100,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 				SetChecks(checks).
 				SetConfig(config).
 				SetOverrides(setOverridesFlag).
+				SetToolVersion(Version).
 				Build()
 
 			if err != nil {
@@ -124,6 +129,17 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 				cmd.Println(string(b))
 			} else {
 				cmd.Print(result)
+			}
+
+			reportErr := chartverifier.
+				NewReportBuilder().
+				SetCertificate(&result).
+				SetChartUri(args[0]).
+				Generate()
+
+			if reportErr != nil {
+				cmd.Println("Report failure :" + reportErr.Error())
+				return err
 			}
 
 			return nil

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -28,9 +28,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
 )
 
-const (
-	Version = "1.0.0"
-)
+var Version = "1.0.0"
 
 func init() {
 	allChecks = chartverifier.DefaultRegistry().AllChecks()

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -113,8 +113,12 @@ func TestCertify(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 		require.NotEmpty(t, outBuf.String())
 
-		expected := "chart: chart\n" +
-			"version: 1.16.0\n" +
+		expected := "Tool:\n" +
+			"  verifier-version: 1.0.0\n" +
+			"  chart-uri: ../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz\n" +
+			"Chart:\n" +
+			"  Name: chart\n" +
+			"  version: 1.16.0\n" +
 			"ok: true\n" +
 			"\n" +
 			"is-helm-v3:\n" +
@@ -145,6 +149,10 @@ func TestCertify(t *testing.T) {
 
 		expected := map[string]interface{}{
 			"metadata": map[string]interface{}{
+				"tool": map[string]interface{}{
+					"verifier-version": "1.0.0",
+					"chart-uri":        "../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
+				},
 				"chart": map[string]interface{}{
 					"name":    "chart",
 					"version": "1.16.0",
@@ -183,6 +191,10 @@ func TestCertify(t *testing.T) {
 
 		expected := map[string]interface{}{
 			"metadata": map[string]interface{}{
+				"tool": map[string]interface{}{
+					"verifier-version": "1.0.0",
+					"chart-uri":        "../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
+				},
 				"chart": map[string]interface{}{
 					"name":    "chart",
 					"version": "1.16.0",

--- a/pkg/chartverifier/certificate.go
+++ b/pkg/chartverifier/certificate.go
@@ -23,12 +23,22 @@ type chartMetadata struct {
 	Version string `json:"version" yaml:"version"`
 }
 
+type runMetadata struct {
+	Version  string `json:"verifier-version" yaml:"verifier-version"`
+	ChartUri string `json:"chart-uri" yaml:"chart-uri"`
+}
+
 type metadata struct {
+	RunMetadata   runMetadata   `json:"tool" yaml:"tool"`
 	ChartMetadata chartMetadata `json:"chart" yaml:"chart"`
 }
 
-func newMetadata(name, version string) *metadata {
+func newMetadata(name, version, chartUri, toolVersion string) *metadata {
 	return &metadata{
+		RunMetadata: runMetadata{
+			ChartUri: chartUri,
+			Version:  toolVersion,
+		},
 		ChartMetadata: chartMetadata{
 			Name:    name,
 			Version: version,
@@ -49,9 +59,9 @@ type checkResult struct {
 	Reason string `json:"reason" yaml:"reason"`
 }
 
-func newCertificate(name, version string, ok bool, resultMap checkResultMap) Certificate {
+func newCertificate(name, version, chartUri, toolVersion string, ok bool, resultMap checkResultMap) Certificate {
 	return &certificate{
-		Metadata:       newMetadata(name, version),
+		Metadata:       newMetadata(name, version, chartUri, toolVersion),
 		Ok:             ok,
 		CheckResultMap: resultMap,
 	}
@@ -62,8 +72,12 @@ func (c *certificate) IsOk() bool {
 }
 
 func (c *certificate) String() string {
-	report := "chart: " + c.Metadata.ChartMetadata.Name + "\n" +
-		"version: " + c.Metadata.ChartMetadata.Version + "\n" +
+	report := "Tool:\n" +
+		"  verifier-version: " + c.Metadata.RunMetadata.Version + "\n" +
+		"  chart-uri: " + c.Metadata.RunMetadata.ChartUri + "\n" +
+		"Chart:\n" +
+		"  Name: " + c.Metadata.ChartMetadata.Name + "\n" +
+		"  version: " + c.Metadata.ChartMetadata.Version + "\n" +
 		"ok: " + strconv.FormatBool(c.Ok) + "\n" +
 		"\n"
 

--- a/pkg/chartverifier/certificatebuilder.go
+++ b/pkg/chartverifier/certificatebuilder.go
@@ -23,6 +23,8 @@ import (
 )
 
 type CertificateBuilder interface {
+	SetToolVersion(name string) CertificateBuilder
+	SetChartUri(name string) CertificateBuilder
 	SetChartName(name string) CertificateBuilder
 	SetChartVersion(version string) CertificateBuilder
 	AddCheckResult(name string, result checks.Result) CertificateBuilder
@@ -35,6 +37,8 @@ type CheckResult struct {
 }
 
 type certificateBuilder struct {
+	ToolVersion    string
+	ChartUri       string
 	ChartName      string
 	ChartVersion   string
 	CheckResultMap checkResultMap
@@ -44,6 +48,16 @@ func NewCertificateBuilder() CertificateBuilder {
 	return &certificateBuilder{
 		CheckResultMap: checkResultMap{},
 	}
+}
+
+func (r *certificateBuilder) SetToolVersion(version string) CertificateBuilder {
+	r.ToolVersion = version
+	return r
+}
+
+func (r *certificateBuilder) SetChartUri(uri string) CertificateBuilder {
+	r.ChartUri = uri
+	return r
 }
 
 func (r *certificateBuilder) SetChartName(name string) CertificateBuilder {
@@ -62,6 +76,7 @@ func (r *certificateBuilder) AddCheckResult(name string, result checks.Result) C
 }
 
 func (r *certificateBuilder) Build() (Certificate, error) {
+
 	if r.ChartName == "" {
 		return nil, errors.New("chart name must be set")
 	}
@@ -79,5 +94,5 @@ func (r *certificateBuilder) Build() (Certificate, error) {
 		}
 	}
 
-	return newCertificate(r.ChartName, r.ChartVersion, ok, r.CheckResultMap), nil
+	return newCertificate(r.ChartName, r.ChartVersion, r.ChartUri, r.ToolVersion, ok, r.CheckResultMap), nil
 }

--- a/pkg/chartverifier/certifier.go
+++ b/pkg/chartverifier/certifier.go
@@ -41,6 +41,7 @@ type certifier struct {
 	config         *viper.Viper
 	registry       checks.Registry
 	requiredChecks []string
+	toolVersion    string
 }
 
 func (c *certifier) subConfig(name string) *viper.Viper {
@@ -60,7 +61,9 @@ func (c *certifier) Certify(uri string) (Certificate, error) {
 
 	result := NewCertificateBuilder().
 		SetChartName(chrt.Name()).
-		SetChartVersion(chrt.AppVersion())
+		SetChartVersion(chrt.AppVersion()).
+		SetToolVersion(c.toolVersion).
+		SetChartUri(uri)
 
 	for _, name := range c.requiredChecks {
 		checkFunc, ok := c.registry.Get(name)

--- a/pkg/chartverifier/certifierbuilder.go
+++ b/pkg/chartverifier/certifierbuilder.go
@@ -45,10 +45,11 @@ func DefaultRegistry() checks.Registry {
 }
 
 type certifierBuilder struct {
-	checks    []string
-	config    *viper.Viper
-	overrides []string
-	registry  checks.Registry
+	checks      []string
+	config      *viper.Viper
+	overrides   []string
+	registry    checks.Registry
+	toolVersion string
 }
 
 func (b *certifierBuilder) SetRegistry(registry checks.Registry) CertifierBuilder {
@@ -68,6 +69,11 @@ func (b *certifierBuilder) SetConfig(config *viper.Viper) CertifierBuilder {
 
 func (b *certifierBuilder) SetOverrides(overrides []string) CertifierBuilder {
 	b.overrides = overrides
+	return b
+}
+
+func (b *certifierBuilder) SetToolVersion(version string) CertifierBuilder {
+	b.toolVersion = version
 	return b
 }
 
@@ -94,6 +100,7 @@ func (b *certifierBuilder) Build() (Certifier, error) {
 		registry:       b.registry,
 		requiredChecks: b.checks,
 		config:         b.config,
+		toolVersion:    b.toolVersion,
 	}, nil
 }
 

--- a/pkg/chartverifier/helmcertifier.go
+++ b/pkg/chartverifier/helmcertifier.go
@@ -26,6 +26,7 @@ type CertifierBuilder interface {
 	SetChecks(checks []string) CertifierBuilder
 	SetConfig(config *viper.Viper) CertifierBuilder
 	SetOverrides([]string) CertifierBuilder
+	SetToolVersion(string) CertifierBuilder
 	Build() (Certifier, error)
 }
 

--- a/pkg/chartverifier/reportbuilder.go
+++ b/pkg/chartverifier/reportbuilder.go
@@ -1,0 +1,105 @@
+package chartverifier
+
+import (
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/chart"
+	"os"
+	"path/filepath"
+)
+
+type ReportBuilder interface {
+	SetCertificate(*Certificate) ReportBuilder
+	SetChartUri(string) ReportBuilder
+	AddChartYaml(*chart.File) ReportBuilder
+	Generate() error
+}
+
+type reportBuilder struct {
+	Certificate *Certificate
+	ChartUri    string
+	ChartYaml   *chart.File
+}
+
+type chartYamlMetadata struct {
+	ChartYamlMetadata interface{} `json:"chart-yaml" yaml:"chart-yaml"`
+}
+
+func newChartYamlMetadata(data interface{}) *chartYamlMetadata {
+	return &chartYamlMetadata{
+		ChartYamlMetadata: data,
+	}
+}
+
+func NewReportBuilder() ReportBuilder {
+	return &reportBuilder{}
+}
+
+func (r *reportBuilder) SetCertificate(cert *Certificate) ReportBuilder {
+	r.Certificate = cert
+	return r
+}
+
+func (r *reportBuilder) SetChartUri(uri string) ReportBuilder {
+	r.ChartUri = uri
+	return r
+}
+
+func (r *reportBuilder) AddChartYaml(file *chart.File) ReportBuilder {
+	r.ChartYaml = file
+	return r
+}
+
+func (r *reportBuilder) Generate() error {
+
+	var err error
+	reportsDir := "reports"
+	if _, err = os.Stat(reportsDir); os.IsNotExist(err) {
+		err = os.Mkdir(reportsDir, 0755)
+	}
+	if err != nil {
+		return err
+	}
+
+	reportDir := filepath.FromSlash(reportsDir + "/" + filepath.Base(r.ChartUri))
+
+	if _, err = os.Stat(reportDir); !os.IsNotExist(err) {
+		os.RemoveAll(reportDir)
+	}
+	if err = os.Mkdir(reportDir, 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(reportDir + "/verifier.report.yaml")
+	if err != nil {
+		return err
+	}
+
+	b, err := yaml.Marshal(r.Certificate)
+	if err != nil {
+		return err
+	}
+
+	f.Write(b)
+
+	c, _, err := checks.LoadChartFromURI(r.ChartUri)
+	for _, chartFile := range c.Raw {
+		if chartFile.Name == "Chart.yaml" {
+			var unmarshalledChart interface{}
+			err = yaml.Unmarshal(chartFile.Data, &unmarshalledChart)
+			if err != nil {
+				return err
+			}
+			b, err = yaml.Marshal(newChartYamlMetadata(unmarshalledChart))
+			if err != nil {
+				return err
+			}
+			f.Write(b)
+			break
+		}
+	}
+
+	f.Close()
+
+	return err
+}


### PR DESCRIPTION
First pass at generating a report (everything could still change) - next steps are to add other info as requested, add some tests, and update the readme with instructions. 

Note the report is not generate if the tool is run as a container image, that will also follow.

The report is generated in a reports folder in the directory from which the cv tool is run. For example for the command:

```out/chart-verifier verify pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz```

a report is generated  ```reports/chart-0.1.0-v3.valid.tgz/verifier.report.yaml```

if the tool is re-run the existing report is overwritten. Content for the report is as follows:

```ok: true
metadata:
    tool:
        verifier-version: 1.0.0
        chart-uri: pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz
    chart:
        name: chart
        version: 1.16.0
results:
    contains-test:
        ok: true
        reason: Chart test files exist
    contains-values:
        ok: true
        reason: Values file exist
    contains-values-schema:
        ok: true
        reason: Values schema file exist
    has-minkubeversion:
        ok: true
        reason: Minimum Kubernetes version specified
    has-readme:
        ok: true
        reason: Chart has a README
    helm-lint:
        ok: true
        reason: Helm lint successful
    is-helm-v3:
        ok: true
        reason: API version is V2, used in Helm 3
    not-contain-csi-objects:
        ok: true
        reason: CSI objects do not exist
    not-contains-crds:
        ok: true
        reason: Chart does not contain CRDs
chart-yaml:
    apiVersion: v2
    appVersion: 1.16.0
    description: A Helm chart for Kubernetes
    icon: https://www.example.com/chart-icon.png
    kubeVersion: 1.20.0
    name: chart
    type: application
    version: 0.1.0-v3.valid```