### PR TITLE
New certificate schema, mandatory type, chart sha and timestamp

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -135,28 +135,14 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 				cmd.Println(string(b))
 
-			} else if outputFormatFlag == "yaml" {
+			} else {
 				b, err := yaml.Marshal(result)
 				if err != nil {
 					return err
 				}
 
 				cmd.Println(string(b))
-			} else {
-				cmd.Print(result)
 			}
-
-			reportErr := chartverifier.
-				NewReportBuilder().
-				SetCertificate(&result).
-				SetChartUri(args[0]).
-				Generate()
-
-			if reportErr != nil {
-				cmd.Println("Report failure :" + reportErr.Error())
-				return err
-			}
-
 			return nil
 		},
 	}

--- a/pkg/chartverifier/certificate.go
+++ b/pkg/chartverifier/certificate.go
@@ -31,8 +31,9 @@ const (
 	OptionalCheckType     checks.CheckType = "Optional"
 	ExperimentalCheckType checks.CheckType = "Experimental"
 
-	FailOutcomeType OutcomeType = "FAIL"
-	PassOutcomeType OutcomeType = "PASS"
+	FailOutcomeType    OutcomeType = "FAIL"
+	PassOutcomeType    OutcomeType = "PASS"
+	UnknownOutcomeType OutcomeType = "UNKNOWN"
 )
 
 type Certificate struct {
@@ -76,7 +77,7 @@ func (c *Certificate) AddCheck(checkName string, checkType checks.CheckType) *Ch
 	newCheck := CheckReport{}
 	newCheck.Check = checkName
 	newCheck.Type = checkType
-	newCheck.Outcome = PassOutcomeType
+	newCheck.Outcome = UnknownOutcomeType
 	c.Results = append(c.Results, &newCheck)
 	return &newCheck
 }
@@ -94,7 +95,7 @@ func (c *Certificate) IsOk() bool {
 
 	outcome := true
 	for _, check := range c.Results {
-		if check.Outcome == FailOutcomeType {
+		if !(check.Outcome == PassOutcomeType) {
 			outcome = false
 			break
 		}

--- a/pkg/chartverifier/certificatebuilder.go
+++ b/pkg/chartverifier/certificatebuilder.go
@@ -44,9 +44,9 @@ type certificateBuilder struct {
 }
 
 func NewCertificateBuilder() CertificateBuilder {
-	cB := certificateBuilder{}
-	cB.Certificate = newCertificate()
-	return &cB
+	b := certificateBuilder{}
+	b.Certificate = newCertificate()
+	return &b
 }
 
 func (r *certificateBuilder) SetToolVersion(version string) CertificateBuilder {
@@ -87,7 +87,7 @@ type fileSorter struct {
 	by    func(p1, p2 *helmchart.File) bool // Closure used in the Less method.
 }
 
-func (by By) Sort(files []*helmchart.File) {
+func (by By) sort(files []*helmchart.File) {
 	fs := &fileSorter{
 		files: files,
 		by:    by, // The Sort method's receiver is the function (closure) that defines the sort order.
@@ -118,7 +118,7 @@ func GenerateSha(rawFiles []*helmchart.File) string {
 
 	chartSha := sha256.New()
 	sortedFiles := rawFiles
-	By(name).Sort(sortedFiles)
+	By(name).sort(sortedFiles)
 	for _, chartFile := range sortedFiles {
 		chartSha.Write(chartFile.Data)
 	}

--- a/pkg/chartverifier/certificatebuilder.go
+++ b/pkg/chartverifier/certificatebuilder.go
@@ -17,18 +17,20 @@
 package chartverifier
 
 import (
-	"errors"
-
+	"crypto/sha256"
+	"fmt"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	"sort"
+	"time"
 )
 
 type CertificateBuilder interface {
 	SetToolVersion(name string) CertificateBuilder
 	SetChartUri(name string) CertificateBuilder
-	SetChartName(name string) CertificateBuilder
-	SetChartVersion(version string) CertificateBuilder
-	AddCheckResult(name string, result checks.Result) CertificateBuilder
-	Build() (Certificate, error)
+	AddCheck(name string, checkType checks.CheckType, result checks.Result) CertificateBuilder
+	SetChart(chart *helmchart.Chart) CertificateBuilder
+	Build() (*Certificate, error)
 }
 
 type CheckResult struct {
@@ -37,62 +39,89 @@ type CheckResult struct {
 }
 
 type certificateBuilder struct {
-	ToolVersion    string
-	ChartUri       string
-	ChartName      string
-	ChartVersion   string
-	CheckResultMap checkResultMap
+	Chart       *helmchart.Chart
+	Certificate Certificate
 }
 
 func NewCertificateBuilder() CertificateBuilder {
-	return &certificateBuilder{
-		CheckResultMap: checkResultMap{},
-	}
+	cB := certificateBuilder{}
+	cB.Certificate = newCertificate()
+	return &cB
 }
 
 func (r *certificateBuilder) SetToolVersion(version string) CertificateBuilder {
-	r.ToolVersion = version
+	r.Certificate.Metadata.ToolMetadata.Version = version
 	return r
 }
 
 func (r *certificateBuilder) SetChartUri(uri string) CertificateBuilder {
-	r.ChartUri = uri
+	r.Certificate.Metadata.ToolMetadata.ChartUri = uri
 	return r
 }
 
-func (r *certificateBuilder) SetChartName(name string) CertificateBuilder {
-	r.ChartName = name
+func (r *certificateBuilder) SetChart(chart *helmchart.Chart) CertificateBuilder {
+	r.Chart = chart
+	r.Certificate.Metadata.ChartData = chart.Metadata
 	return r
 }
 
-func (r *certificateBuilder) SetChartVersion(version string) CertificateBuilder {
-	r.ChartVersion = version
+func (r *certificateBuilder) AddCheck(name string, checkType checks.CheckType, result checks.Result) CertificateBuilder {
+	checkReport := r.Certificate.AddCheck(name, checkType)
+	checkReport.SetResult(result.Ok, result.Reason)
 	return r
 }
 
-func (r *certificateBuilder) AddCheckResult(name string, result checks.Result) CertificateBuilder {
-	r.CheckResultMap[name] = checkResult{Ok: result.Ok, Reason: result.Reason}
-	return r
+func (r *certificateBuilder) Build() (*Certificate, error) {
+
+	r.Certificate.Metadata.ToolMetadata.Digest = GenerateSha(r.Chart.Raw)
+
+	r.Certificate.Metadata.ToolMetadata.LastCertifiedTime = time.Now().String()
+
+	return &r.Certificate, nil
 }
 
-func (r *certificateBuilder) Build() (Certificate, error) {
+type By func(p1, p2 *helmchart.File) bool
 
-	if r.ChartName == "" {
-		return nil, errors.New("chart name must be set")
+type fileSorter struct {
+	files []*helmchart.File
+	by    func(p1, p2 *helmchart.File) bool // Closure used in the Less method.
+}
+
+func (by By) Sort(files []*helmchart.File) {
+	fs := &fileSorter{
+		files: files,
+		by:    by, // The Sort method's receiver is the function (closure) that defines the sort order.
+	}
+	sort.Sort(fs)
+}
+
+// Len is part of sort.Interface.
+func (fs *fileSorter) Len() int {
+	return len(fs.files)
+}
+
+// Swap is part of sort.Interface.
+func (fs *fileSorter) Swap(i, j int) {
+	fs.files[i], fs.files[j] = fs.files[j], fs.files[i]
+}
+
+// Less is part of sort.Interface. It is implemented by calling the "by" closure in the sorter.
+func (fs *fileSorter) Less(i, j int) bool {
+	return fs.by(fs.files[i], fs.files[j])
+}
+
+func GenerateSha(rawFiles []*helmchart.File) string {
+
+	name := func(f1, f2 *helmchart.File) bool {
+		return f1.Name < f2.Name
 	}
 
-	if r.ChartVersion == "" {
-		return nil, errors.New("chart version must be set")
+	chartSha := sha256.New()
+	sortedFiles := rawFiles
+	By(name).Sort(sortedFiles)
+	for _, chartFile := range sortedFiles {
+		chartSha.Write(chartFile.Data)
 	}
 
-	ok := true
-
-	for _, v := range r.CheckResultMap {
-		if !v.Ok {
-			ok = false
-			break
-		}
-	}
-
-	return newCertificate(r.ChartName, r.ChartVersion, r.ChartUri, r.ToolVersion, ok, r.CheckResultMap), nil
+	return fmt.Sprintf("sha256:%x", chartSha.Sum(nil))
 }

--- a/pkg/chartverifier/certificatebuilder_test.go
+++ b/pkg/chartverifier/certificatebuilder_test.go
@@ -1,0 +1,45 @@
+package chartverifier
+
+import (
+	"testing"
+
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSha(t *testing.T) {
+
+	charts := []string{"checks/chart-0.1.0-v3.with-csi.tgz",
+		"checks/chart-0.1.0-v3.valid.tgz",
+		"checks/chart-0.1.0-v2.invalid.tgz",
+		"checks/chart-0.1.0-v3.without-readme.tgz",
+		"checks/chart-0.1.0-v3.with-crd.tgz"}
+
+	shas := make(map[string]string)
+
+	// get shas for each file
+	for _, chart := range charts {
+		t.Run("Sha generation : "+chart, func(t *testing.T) {
+			helmChart, _, err := checks.LoadChartFromURI(chart)
+			require.NoError(t, err)
+			sha := GenerateSha(helmChart.Raw)
+			require.NotNil(t, sha)
+			shas[chart] = sha
+		})
+	}
+
+	for i := 0; i < 5; i++ {
+		// get sha's again and make sure they match
+		for _, chart := range charts {
+
+			t.Run("Sha must not change : "+chart, func(t *testing.T) {
+				helmChart, _, err := checks.LoadChartFromURI(chart)
+				require.NoError(t, err)
+				sha := GenerateSha(helmChart.Raw)
+				require.NotNil(t, sha)
+				require.Equal(t, shas[chart], sha)
+			})
+		}
+	}
+
+}

--- a/pkg/chartverifier/certifier_test.go
+++ b/pkg/chartverifier/certifier_test.go
@@ -66,7 +66,7 @@ func TestCertifier_Certify(t *testing.T) {
 	t.Run("Should return error if check exists and returns error", func(t *testing.T) {
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, erroredCheck),
+			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: erroredCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 
@@ -79,7 +79,7 @@ func TestCertifier_Certify(t *testing.T) {
 
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, negativeCheck),
+			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: negativeCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 
@@ -92,7 +92,7 @@ func TestCertifier_Certify(t *testing.T) {
 	t.Run("Result should be positive if check exists and returns positive", func(t *testing.T) {
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, positiveCheck),
+			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: positiveCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 

--- a/pkg/chartverifier/certifier_test.go
+++ b/pkg/chartverifier/certifier_test.go
@@ -66,7 +66,7 @@ func TestCertifier_Certify(t *testing.T) {
 	t.Run("Should return error if check exists and returns error", func(t *testing.T) {
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: erroredCheck}),
+			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: erroredCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 
@@ -79,7 +79,7 @@ func TestCertifier_Certify(t *testing.T) {
 
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: negativeCheck}),
+			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: negativeCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 
@@ -92,7 +92,7 @@ func TestCertifier_Certify(t *testing.T) {
 	t.Run("Result should be positive if check exists and returns positive", func(t *testing.T) {
 		c := &certifier{
 			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(dummyCheckName, checks.Check{Type: MandatoryCheckType, Func: positiveCheck}),
+			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
 			requiredChecks: []string{dummyCheckName},
 		}
 

--- a/pkg/chartverifier/certifierbuilder.go
+++ b/pkg/chartverifier/certifierbuilder.go
@@ -29,16 +29,16 @@ var defaultRegistry checks.Registry
 
 func init() {
 	defaultRegistry = checks.NewRegistry()
-	defaultRegistry.Add("has-readme", checks.HasReadme)
-	defaultRegistry.Add("is-helm-v3", checks.IsHelmV3)
-	defaultRegistry.Add("contains-test", checks.ContainsTest)
-	defaultRegistry.Add("contains-values", checks.ContainsValues)
-	defaultRegistry.Add("contains-values-schema", checks.ContainsValuesSchema)
-	defaultRegistry.Add("has-minkubeversion", checks.HasMinKubeVersion)
-	defaultRegistry.Add("not-contains-crds", checks.NotContainCRDs)
-	defaultRegistry.Add("helm-lint", checks.HelmLint)
-	defaultRegistry.Add("not-contain-csi-objects", checks.NotContainCSIObjects)
-	defaultRegistry.Add("images-are-certified", checks.ImagesAreCertified)
+	defaultRegistry.Add("has-readme", checks.Check{Type: MandatoryCheckType, Func: checks.HasReadme})
+	defaultRegistry.Add("is-helm-v3", checks.Check{Type: MandatoryCheckType, Func: checks.IsHelmV3})
+	defaultRegistry.Add("contains-test", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsTest})
+	defaultRegistry.Add("contains-values", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsValues})
+	defaultRegistry.Add("contains-values-schema", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsValuesSchema})
+	defaultRegistry.Add("has-minkubeversion", checks.Check{Type: MandatoryCheckType, Func: checks.HasMinKubeVersion})
+	defaultRegistry.Add("not-contains-crds", checks.Check{Type: MandatoryCheckType, Func: checks.NotContainCRDs})
+	defaultRegistry.Add("helm-lint", checks.Check{Type: MandatoryCheckType, Func: checks.HelmLint})
+	defaultRegistry.Add("not-contain-csi-objects", checks.Check{Type: MandatoryCheckType, Func: checks.NotContainCSIObjects})
+	defaultRegistry.Add("images-are-certified", checks.Check{Type: MandatoryCheckType, Func: checks.ImagesAreCertified})
 }
 
 func DefaultRegistry() checks.Registry {

--- a/pkg/chartverifier/certifierbuilder.go
+++ b/pkg/chartverifier/certifierbuilder.go
@@ -29,16 +29,16 @@ var defaultRegistry checks.Registry
 
 func init() {
 	defaultRegistry = checks.NewRegistry()
-	defaultRegistry.Add("has-readme", checks.Check{Type: MandatoryCheckType, Func: checks.HasReadme})
-	defaultRegistry.Add("is-helm-v3", checks.Check{Type: MandatoryCheckType, Func: checks.IsHelmV3})
-	defaultRegistry.Add("contains-test", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsTest})
-	defaultRegistry.Add("contains-values", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsValues})
-	defaultRegistry.Add("contains-values-schema", checks.Check{Type: MandatoryCheckType, Func: checks.ContainsValuesSchema})
-	defaultRegistry.Add("has-minkubeversion", checks.Check{Type: MandatoryCheckType, Func: checks.HasMinKubeVersion})
-	defaultRegistry.Add("not-contains-crds", checks.Check{Type: MandatoryCheckType, Func: checks.NotContainCRDs})
-	defaultRegistry.Add("helm-lint", checks.Check{Type: MandatoryCheckType, Func: checks.HelmLint})
-	defaultRegistry.Add("not-contain-csi-objects", checks.Check{Type: MandatoryCheckType, Func: checks.NotContainCSIObjects})
-	defaultRegistry.Add("images-are-certified", checks.Check{Type: MandatoryCheckType, Func: checks.ImagesAreCertified})
+	defaultRegistry.Add(checks.Check{Name: "has-readme", Type: MandatoryCheckType, Func: checks.HasReadme})
+	defaultRegistry.Add(checks.Check{Name: "is-helm-v3", Type: MandatoryCheckType, Func: checks.IsHelmV3})
+	defaultRegistry.Add(checks.Check{Name: "contains-test", Type: MandatoryCheckType, Func: checks.ContainsTest})
+	defaultRegistry.Add(checks.Check{Name: "contains-values", Type: MandatoryCheckType, Func: checks.ContainsValues})
+	defaultRegistry.Add(checks.Check{Name: "contains-values-schema", Type: MandatoryCheckType, Func: checks.ContainsValuesSchema})
+	defaultRegistry.Add(checks.Check{Name: "has-minkubeversion", Type: MandatoryCheckType, Func: checks.HasMinKubeVersion})
+	defaultRegistry.Add(checks.Check{Name: "not-contains-crds", Type: MandatoryCheckType, Func: checks.NotContainCRDs})
+	defaultRegistry.Add(checks.Check{Name: "helm-lint", Type: MandatoryCheckType, Func: checks.HelmLint})
+	defaultRegistry.Add(checks.Check{Name: "not-contain-csi-objects", Type: MandatoryCheckType, Func: checks.NotContainCSIObjects})
+	defaultRegistry.Add(checks.Check{Name: "images-are-certified", Type: MandatoryCheckType, Func: checks.ImagesAreCertified})
 }
 
 func DefaultRegistry() checks.Registry {

--- a/pkg/chartverifier/checks/registry.go
+++ b/pkg/chartverifier/checks/registry.go
@@ -42,10 +42,18 @@ func (r *Result) SetResult(outcome bool, reason string) Result {
 func (r *Result) AddResult(outcome bool, reason string) Result {
 	r.Ok = r.Ok && outcome
 	if len(r.Reason) > 0 {
-		r.Reason += "\n\t\t"
+		r.Reason += "\n"
 	}
 	r.Reason += reason
 	return *r
+}
+
+type CheckType string
+
+type Check struct {
+	Name string
+	Type CheckType
+	Func CheckFunc
 }
 
 // CheckOptions contains options collected from the environment a check can
@@ -62,12 +70,12 @@ type CheckOptions struct {
 type CheckFunc func(options *CheckOptions) (Result, error)
 
 type Registry interface {
-	Get(name string) (CheckFunc, bool)
-	Add(name string, checkFunc CheckFunc) Registry
+	Get(name string) (Check, bool)
+	Add(name string, check Check) Registry
 	AllChecks() []string
 }
 
-type defaultRegistry map[string]CheckFunc
+type defaultRegistry map[string]Check
 
 func (r *defaultRegistry) AllChecks() []string {
 	allChecks := make([]string, 0)
@@ -81,12 +89,12 @@ func NewRegistry() Registry {
 	return &defaultRegistry{}
 }
 
-func (r *defaultRegistry) Get(name string) (CheckFunc, bool) {
+func (r *defaultRegistry) Get(name string) (Check, bool) {
 	v, ok := (*r)[name]
 	return v, ok
 }
 
-func (r *defaultRegistry) Add(name string, checkFunc CheckFunc) Registry {
-	(*r)[name] = checkFunc
+func (r *defaultRegistry) Add(name string, check Check) Registry {
+	(*r)[name] = check
 	return r
 }

--- a/pkg/chartverifier/checks/registry.go
+++ b/pkg/chartverifier/checks/registry.go
@@ -71,7 +71,7 @@ type CheckFunc func(options *CheckOptions) (Result, error)
 
 type Registry interface {
 	Get(name string) (Check, bool)
-	Add(name string, check Check) Registry
+	Add(check Check) Registry
 	AllChecks() []string
 }
 
@@ -94,7 +94,7 @@ func (r *defaultRegistry) Get(name string) (Check, bool) {
 	return v, ok
 }
 
-func (r *defaultRegistry) Add(name string, check Check) Registry {
-	(*r)[name] = check
+func (r *defaultRegistry) Add(check Check) Registry {
+	(*r)[check.Name] = check
 	return r
 }

--- a/pkg/chartverifier/helmcertifier.go
+++ b/pkg/chartverifier/helmcertifier.go
@@ -32,9 +32,5 @@ type CertifierBuilder interface {
 }
 
 type Certifier interface {
-	Certify(uri string) (Certificate, error)
-}
-
-type Certificate interface {
-	IsOk() bool
+	Certify(uri string) (*Certificate, error)
 }


### PR DESCRIPTION
This PR covers several things

1. New schema implemented. See "Certificate" struct in chartverifier/Certificate.go 
2. Added ability to mark checks as Mandatory, Optional or Experimental. All current checks are mandatory
3. Generating a sha256 value for the chart. Basically sort all files into alphabetic order and then create sha from their content. Test case repeatedly creates sha calues for test charts making sure they are always the same.
4. Report is output to console and no longer a file. Running locallly use "command 2> report.yaml", running docker image just "command > report.yaml"
5. Default output is now yaml. 
6. Some tests had to be updated for the new changes and schema