### PR TITLE
Store error from yaml in a new variable

### DIFF
--- a/pkg/chartverifier/checks/helm.go
+++ b/pkg/chartverifier/checks/helm.go
@@ -217,8 +217,8 @@ func getImageReferences(chartUri string, vals map[string]interface{}) ([]string,
 		for scanner.Scan() {
 			line := scanner.Text()
 			var imageRef ImageRef
-			err = yaml.Unmarshal([]byte(line), &imageRef)
-			if err == nil {
+			yamlErr := yaml.Unmarshal([]byte(line), &imageRef)
+			if yamlErr == nil {
 				if len(imageRef.Ref) > 0 && !imagesMap[imageRef.Ref] {
 					imagesMap[imageRef.Ref] = true
 				}


### PR DESCRIPTION
Quick bug fix. 

Code unMarshalls helm template output line by line, if it fails for a line it is ignored and the next line is processed. Problem was the error was saved in the same variable used to return an error from the enclosing function so if harmless yaml error occurs the caller thinks the function failed, and image certification fails.

Updated code to use a specific error variable for unMarshall errors.