### PR TITLE
Add chart-testing dependencies to chart-verifier's container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,16 @@ RUN go mod download
 
 COPY . .
 
+RUN ./hack/get-oc.sh
+
+RUN ./hack/get-helm.sh
+
 RUN ./hack/build.sh
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=build /tmp/src/out/chart-verifier /app/chart-verifier
+
+COPY --from=build /usr/local/bin/* /usr/local/bin/
 
 ENTRYPOINT ["/app/chart-verifier"]

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ test:
 	 go test -v ./...
 
 
+.PHONY: build-image
+build-image:
+	hack/build-image.sh

--- a/hack/get-helm.sh
+++ b/hack/get-helm.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+curl -O https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.5.0/helm-linux-amd64.tar.gz
+mkdir -p /usr/local/bin
+tar xfz helm-linux-amd64.tar.gz -C /usr/local/bin
+mv /usr/local/bin/helm-linux-amd64 /usr/local/bin/helm

--- a/hack/get-oc.sh
+++ b/hack/get-oc.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl -O https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.9/openshift-client-linux-4.7.9.tar.gz
+mkdir -p /usr/local/bin
+tar xfz  openshift-client-linux-4.7.9.tar.gz -C /usr/local/bin


### PR DESCRIPTION
The `chart-testing` check depends on third party binaries
(specifically `kubectl` and `helm`), so those should be included in
the resulting image.

OpenShift's `oc` should be provided as well (please note it already
contains a symbolic link to `kubectl`), which is a chart-verifier
dependency to obtain the version of the available OpenShift
connection.