### PR TITLE
chart-verifier output contains more than the report

### DIFF
--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -7,8 +7,8 @@ import (
 	"github.com/helm/chart-testing/v3/pkg/chart"
 	"github.com/helm/chart-testing/v3/pkg/config"
 	"github.com/helm/chart-testing/v3/pkg/exec"
-	"github.com/helm/chart-testing/v3/pkg/tool"
 	"github.com/helm/chart-testing/v3/pkg/util"
+	"github.com/redhat-certification/chart-verifier/pkg/tool"
 )
 
 // buildChartTestingConfiguration computes the chart testing related

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -1,0 +1,46 @@
+package tool
+
+import (
+	"github.com/helm/chart-testing/v3/pkg/exec"
+	"github.com/helm/chart-testing/v3/pkg/tool"
+)
+
+// Helm is an interface to the helm binary; it is a thin layer on top of the Helm abstraction offered by chart-testing
+// to silence output being streamed to Stdout.
+type Helm struct {
+	tool.Helm
+	exec.ProcessExecutor
+	extraArgs []string
+}
+
+func NewHelm(exec exec.ProcessExecutor, extraArgs []string) Helm {
+	return Helm{
+		tool.NewHelm(exec, extraArgs),
+		exec,
+		extraArgs,
+	}
+}
+
+func (h Helm) InstallWithValues(chart string, valuesFile string, namespace string, release string) error {
+	var values []string
+	if valuesFile != "" {
+		values = []string{"--values", valuesFile}
+	}
+
+	if _, err := h.RunProcessAndCaptureOutput("helm", "install", release, chart, "--namespace", namespace,
+		"--wait", values, h.extraArgs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h Helm) Test(namespace string, release string) error {
+	_, err := h.RunProcessAndCaptureOutput("helm", "test", release, "--namespace", namespace, h.extraArgs)
+	return err
+}
+
+func (h Helm) DeleteRelease(namespace string, release string) {
+	_, _ = h.RunProcessAndCaptureOutput("helm", "uninstall", release, "--namespace", namespace, h.extraArgs)
+
+}

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -1,0 +1,56 @@
+package tool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/helm/chart-testing/v3/pkg/exec"
+	"github.com/helm/chart-testing/v3/pkg/tool"
+)
+
+// Kubectl is an interface to the helm binary; it is a thin layer on top of the Kubectl abstraction offered by
+// chart-testing to silence output being streamed to Stdout.
+type Kubectl struct {
+	tool.Kubectl
+	exec.ProcessExecutor
+}
+
+func NewKubectl(exec exec.ProcessExecutor) Kubectl {
+	return Kubectl{
+		tool.NewKubectl(exec),
+		exec,
+	}
+}
+
+func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
+	output, err := k.RunProcessAndCaptureOutput(
+		"kubectl", "get", "deployments", "--namespace", namespace, "--selector", selector, "--output", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return err
+	}
+
+	deployments := strings.Fields(output)
+	for _, deployment := range deployments {
+		deployment = strings.Trim(deployment, "'")
+		_, err := k.RunProcessAndCaptureOutput("kubectl", "rollout", "status", "deployment", deployment, "--namespace", namespace)
+		if err != nil {
+			return err
+		}
+
+		// 'kubectl rollout status' does not return a non-zero exit code when rollouts fail.
+		// We, thus, need to double-check here.
+		//
+		// Just after rollout, pods from the previous deployment revision may still be in a
+		// terminating state.
+		unavailable, err := k.RunProcessAndCaptureOutput("kubectl", "get", "deployment", deployment, "--namespace", namespace, "--output",
+			`jsonpath={.status.unavailableReplicas}`)
+		if err != nil {
+			return err
+		}
+		if unavailable != "" && unavailable != "0" {
+			return fmt.Errorf("%s replicas unavailable", unavailable)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The chart-verifier output since the introduction of the chart-testing
check includes `helm test` and other command output that aren't
expected.

The output should contain only the report's YAML (or JSON)
representation.