### PR TITLE
Set openshiftVersion value through a CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,29 @@ Usage:
   chart-verifier verify <chart-uri> [flags]
 
 Flags:
-  -x, --disable strings   all checks will be enabled except the informed ones
-  -e, --enable strings    only the informed checks will be enabled
-  -h, --help              help for verify
-  -o, --output string     the output format: default, json or yaml
+  -S, --chart-set strings           set values for the chart (can specify multiple or separate values with commas: key1=val1,key2=val2)
+  -G, --chart-set-file strings      set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+  -X, --chart-set-string strings    set STRING values for the chart (can specify multiple or separate values with commas: key1=val1,key2=val2)
+  -F, --chart-values strings        specify values in a YAML file or a URL (can specify multiple)
+      --debug                       enable verbose output
+  -x, --disable strings             all checks will be enabled except the informed ones
+  -e, --enable strings              only the informed checks will be enabled
+  -h, --help                        help for verify
+      --kube-apiserver string       the address and the port for the Kubernetes API server
+      --kube-as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --kube-as-user string         username to impersonate for the operation
+      --kube-ca-file string         the certificate authority file for the Kubernetes API server connection
+      --kube-context string         name of the kubeconfig context to use
+      --kube-token string           bearer token used for authentication
+      --kubeconfig string           path to the kubeconfig file
+  -n, --namespace string            namespace scope for this request
+  -V, --openshift-version string    set the value of certifiedOpenShiftVersions in the report
+  -o, --output string               the output format: default, json or yaml
+      --registry-config string      path to the registry config file (default "/home/baiju/.config/helm/registry.json")
+      --repository-cache string     path to the file containing cached repository indexes (default "/home/baiju/.cache/helm/repository")
+      --repository-config string    path to the file containing repository names and URLs (default "/home/baiju/.config/helm/repositories.yaml")
+  -s, --set strings                 overrides a configuration, e.g: dummy.ok=false
+  -f, --set-values strings          specify application and check configuration values in a YAML file or a URL (can specify multiple)
 
 Global Flags:
       --config string   config file (default is $HOME/.chart-verifier.yaml)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"encoding/json"
+
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
@@ -49,6 +50,8 @@ var (
 	outputFormatFlag string
 	// setOverridesFlag contains the overrides the user has specified through the --set flag.
 	setOverridesFlag []string
+	// openshiftVersionFlag set the value of `certifiedOpenShiftVersions` in the report
+	openshiftVersionFlag string
 )
 
 func filterChecks(set []string, subset []string, setEnabled bool, subsetEnabled bool) ([]string, error) {
@@ -124,6 +127,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 				SetConfig(config).
 				SetOverrides(verifyOpts.Values).
 				SetToolVersion(Version).
+				SetOpenShiftVersion(openshiftVersionFlag).
 				Build()
 
 			if err != nil {
@@ -174,6 +178,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&verifyOpts.Values, "set", "s", []string{}, "overrides a configuration, e.g: dummy.ok=false")
 
 	cmd.Flags().StringSliceVarP(&verifyOpts.ValueFiles, "set-values", "f", nil, "specify application and check configuration values in a YAML file or a URL (can specify multiple)")
+	cmd.Flags().StringVarP(&openshiftVersionFlag, "openshift-version", "V", "", "version of OpenShift used in the cluster")
 
 	return cmd
 }

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -109,6 +109,7 @@ func TestCertify(t *testing.T) {
 
 		cmd.SetArgs([]string{
 			"-e", "is-helm-v3",
+			"-V", "4.9",
 			"../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
 		})
 		require.NoError(t, cmd.Execute())
@@ -131,6 +132,7 @@ func TestCertify(t *testing.T) {
 
 		cmd.SetArgs([]string{
 			"-e", "is-helm-v3", // only consider a single check, perhaps more checks in the future
+			"-V", "4.9",
 			"-o", "json",
 			"../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
 		})
@@ -157,6 +159,7 @@ func TestCertify(t *testing.T) {
 
 		cmd.SetArgs([]string{
 			"-e", "is-helm-v3", // only consider a single check, perhaps more checks in the future
+			"-V", "4.9",
 			"-o", "yaml",
 			"../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
 		})

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -75,7 +75,6 @@ This section provides help on the basic usage of Helm chart checks with the podm
   The output is similar to the following example:
   ```
   Verifies a Helm chart by checking some of its characteristics
-  Verifies a Helm chart by checking some of its characteristics
 
   Usage:
     chart-verifier verify <chart-uri> [flags]

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -57,58 +57,80 @@ To perform the tasks related to Helm chart checks, run the following commands:
 
 - Runs all the available checks for the chart using a `uri`.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify <chart-uri>
- ```
+  ```
+   $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify <chart-uri>
+   ```
 - Runs all the checks available locally on your system for the chart, from the same directory as the chart.
 
- ```ruby
- $ docker run -v $(pwd):/charts --rm quay.io/redhat-certification/chart-verifier verify /charts/<chart>
- ```
+  ```
+  $ docker run -v $(pwd):/charts --rm quay.io/redhat-certification/chart-verifier verify /charts/<chart>
+  ```
+
 - Gets the list of options for the `verify` command.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify help
- ```
- The output is similar to the following example:
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify help`
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify --help
+  ```
+ 
+  The output is similar to the following example:
 
- Verifies a Helm chart by checking some of its characteristics
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify --help`
 
- Usage:
- chart-verifier verify <chart-uri> [flags]
+  Verifies a Helm chart by checking some of its characteristics
 
- Flags:
-   -S, --chart-set strings          set values for the chart (can specify multiple or separate values with commas:     key1=val1,key2=val2)
-   -F, --chart-set-file strings     set values from respective files specified via the command line (can specify multiple or  separate values with commas: key1=path1,key2=path2)
-   -X, --chart-set-string strings   set STRING values for the chart (can specify multiple or separate values with commas: key1=val1,key2=val2)
-   -f, --chart-values strings       specify values in a YAML file or a URL (can specify multiple)
-   -x, --disable strings            all checks will be enabled except the informed ones
-   -e, --enable strings             only the informed checks will be enabled
-   -h, --help                       help for verify
-   -o, --output string              the output format: default, json or yaml
-   -s, --set strings                overrides a configuration, e.g: dummy.ok=false
+  Usage:
+    chart-verifier verify <chart-uri> [flags]
 
- Global Flags:
-       --config string   config file (default is $HOME/.chart-verifier.yaml)
+  Flags:
+    -S, --chart-set strings           set values for the chart (can specify multiple or separate values with commas: key1=val1,key2=val2)
+    -G, --chart-set-file strings      set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
+    -X, --chart-set-string strings    set STRING values for the chart (can specify multiple or separate values with commas: key1=val1,key2=val2)
+    -F, --chart-values strings        specify values in a YAML file or a URL (can specify multiple)
+        --debug                       enable verbose output
+    -x, --disable strings             all checks will be enabled except the informed ones
+    -e, --enable strings              only the informed checks will be enabled
+    -h, --help                        help for verify
+        --kube-apiserver string       the address and the port for the Kubernetes API server
+        --kube-as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+        --kube-as-user string         username to impersonate for the operation
+        --kube-ca-file string         the certificate authority file for the Kubernetes API server connection
+        --kube-context string         name of the kubeconfig context to use
+        --kube-token string           bearer token used for authentication
+        --kubeconfig string           path to the kubeconfig file
+    -n, --namespace string            namespace scope for this request
+    -V, --openshift-version string    set the value of certifiedOpenShiftVersions in the report
+    -o, --output string               the output format: default, json or yaml
+        --registry-config string      path to the registry config file (default "/home/baiju/.config/helm/registry.json")
+        --repository-cache string     path to the file containing cached repository indexes (default "/home/baiju/.cache/helm/repository")
+        --repository-config string    path to the file containing repository names and URLs (default "/home/baiju/.config/helm/repositories.yaml")
+    -s, --set strings                 overrides a configuration, e.g: dummy.ok=false
+    -f, --set-values strings          specify application and check configuration values in a YAML file or a URL (can specify multiple)
+
+  Global Flags:
+        --config string   config file (default is $HOME/.chart-verifier.yaml)
+  ```
+
 - Runs a subset of the checks.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -e images-are-certified,helm-lint
- ```
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -e images-are-certified,helm-lint
+  ```
+
 - Runs all the checks except a subset.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -x images-are-certified,helm-lint
- ```
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -x images-are-certified,helm-lint
+  ```
+
 - Provides chart-override values.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -S default.port=8080 images-are-certified,helm-lint
- ```
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -S default.port=8080 images-are-certified,helm-lint
+  ```
+
 - Provides chart-override values in a file.
 
- ```ruby
- $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -F overrides.yaml images-are-certified,helm-lint
- ```
+  ```
+  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -F overrides.yaml images-are-certified,helm-lint
+  ```

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -56,30 +56,25 @@ This section provides help on the basic usage of Helm chart checks with the podm
 - Red Hat OpenShift Container Platform cluster.
 
 ### Procedure
-To perform the tasks related to Helm chart checks, run the following commands:
 
-- Runs all the available checks for the chart using a `uri`.
-
-  ```
-   $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify <chart-uri>
-   ```
-- Runs all the checks available locally on your system for the chart, from the same directory as the chart.
+- Run all the available checks for the chart using a `uri`:
 
   ```
-  $ docker run -v $(pwd):/charts --rm quay.io/redhat-certification/chart-verifier verify /charts/<chart>
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify <chart-uri>
   ```
+- Run all the checks available locally on your system for the chart, from the same directory as the chart:
 
-- Gets the list of options for the `verify` command.
+  ```
+  $ podman run -v $(pwd):/charts --rm quay.io/redhat-certification/chart-verifier verify /charts/<chart>
+  ```
+- Get the list of options for the `verify` command:
 
   ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify --help
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify help
   ```
- 
   The output is similar to the following example:
-
   ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify --help`
-
+  Verifies a Helm chart by checking some of its characteristics
   Verifies a Helm chart by checking some of its characteristics
 
   Usage:
@@ -113,27 +108,23 @@ To perform the tasks related to Helm chart checks, run the following commands:
   Global Flags:
         --config string   config file (default is $HOME/.chart-verifier.yaml)
   ```
-
-- Runs a subset of the checks.
-
-  ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -e images-are-certified,helm-lint
-  ```
-
-- Runs all the checks except a subset.
+- Run a subset of the checks:
 
   ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -x images-are-certified,helm-lint
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -e images-are-certified,helm-lint
   ```
-
-- Provides chart-override values.
-
-  ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -S default.port=8080 images-are-certified,helm-lint
-  ```
-
-- Provides chart-override values in a file.
+- Run all the checks except a subset:
 
   ```
-  $ docker run -it --rm quay.io/redhat-certification/chart-verifier verify -F overrides.yaml images-are-certified,helm-lint
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -x images-are-certified,helm-lint
+  ```
+- Provide chart-override values:
+
+  ```
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -S default.port=8080 images-are-certified,helm-lint
+  ```
+- Provide chart-override values in a file:
+
+  ```
+  $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -F overrides.yaml images-are-certified,helm-lint
   ```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/redhat-certification/chart-verifier
 go 1.15
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/helm/chart-testing/v3 v3.3.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/pkg/chartverifier/certificate.go
+++ b/pkg/chartverifier/certificate.go
@@ -46,7 +46,7 @@ type Certificate struct {
 type CertificateMetadata struct {
 	ToolMetadata ToolMetadata        `json:"tool" yaml:"tool"`
 	ChartData    *helmchart.Metadata `json:"chart" yaml:"chart"`
-	Overrides    string              `json: "chart-overrides" yaml:"chart-overrides"`
+	Overrides    string              `json:"chart-overrides" yaml:"chart-overrides"`
 }
 
 type ToolMetadata struct {

--- a/pkg/chartverifier/certifier.go
+++ b/pkg/chartverifier/certifier.go
@@ -17,6 +17,7 @@
 package chartverifier
 
 import (
+	"github.com/Masterminds/semver"
 	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/tool"
@@ -40,6 +41,12 @@ type OpenShiftVersionErr string
 
 func (e OpenShiftVersionErr) Error() string {
 	return "Missing OpenShift version. " + string(e) + " And the 'openshift-version' flag has not set."
+}
+
+type OpenShiftSemVerErr string
+
+func (e OpenShiftSemVerErr) Error() string {
+	return "OpenShift version is not following SemVer spec. " + string(e)
 }
 
 func NewCheckErr(err error) error {
@@ -77,6 +84,9 @@ func (c *certifier) Certify(uri string) (*Certificate, error) {
 	osVersion, err := oc.GetVersion()
 	if err != nil && c.openshiftVersion == "" {
 		return nil, OpenShiftVersionErr(err.Error())
+	}
+	if _, err := semver.NewVersion(c.openshiftVersion); err != nil {
+		return nil, OpenShiftSemVerErr(err.Error())
 	}
 	osVersion = c.openshiftVersion
 

--- a/pkg/chartverifier/certifier.go
+++ b/pkg/chartverifier/certifier.go
@@ -41,7 +41,7 @@ type OpenShiftVersionErr struct {
 }
 
 func (e OpenShiftVersionErr) Error() string {
-	return "Missing OpenShift version. " + string(e.msg)
+	return "Missing OpenShift version. " + string(e.msg) + " And the 'openshift-version' flag has not set."
 }
 
 func NewCheckErr(err error) error {
@@ -76,9 +76,13 @@ func (c *certifier) Certify(uri string) (*Certificate, error) {
 	procExec := exec.NewProcessExecutor(c.settings.Debug)
 	oc := tool.NewOc(procExec)
 
-	osVersion, err := oc.GetVersion(c.openshiftVersion)
+	osVersion, err := oc.GetVersion()
 	if err != nil {
-		return nil, OpenShiftVersionErr{err.Error()}
+		if c.openshiftVersion != "" {
+			osVersion = c.openshiftVersion
+		} else {
+			return nil, OpenShiftVersionErr{err.Error()}
+		}
 	}
 
 	result := NewCertificateBuilder().

--- a/pkg/chartverifier/certifier.go
+++ b/pkg/chartverifier/certifier.go
@@ -36,12 +36,10 @@ func (e CheckErr) Error() string {
 	return "check error: " + string(e)
 }
 
-type OpenShiftVersionErr struct {
-	msg string
-}
+type OpenShiftVersionErr string
 
 func (e OpenShiftVersionErr) Error() string {
-	return "Missing OpenShift version. " + string(e.msg) + " And the 'openshift-version' flag has not set."
+	return "Missing OpenShift version. " + string(e) + " And the 'openshift-version' flag has not set."
 }
 
 func NewCheckErr(err error) error {
@@ -77,13 +75,10 @@ func (c *certifier) Certify(uri string) (*Certificate, error) {
 	oc := tool.NewOc(procExec)
 
 	osVersion, err := oc.GetVersion()
-	if err != nil {
-		if c.openshiftVersion != "" {
-			osVersion = c.openshiftVersion
-		} else {
-			return nil, OpenShiftVersionErr{err.Error()}
-		}
+	if err != nil && c.openshiftVersion == "" {
+		return nil, OpenShiftVersionErr(err.Error())
 	}
+	osVersion = c.openshiftVersion
 
 	result := NewCertificateBuilder().
 		SetToolVersion(c.toolVersion).

--- a/pkg/chartverifier/certifier_test.go
+++ b/pkg/chartverifier/certifier_test.go
@@ -81,10 +81,11 @@ func TestCertifier_Certify(t *testing.T) {
 	t.Run("Result should be negative if check exists and returns negative", func(t *testing.T) {
 
 		c := &certifier{
-			settings:       cli.New(),
-			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: negativeCheck}),
-			requiredChecks: []string{dummyCheckName},
+			settings:         cli.New(),
+			config:           viper.New(),
+			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: negativeCheck}),
+			requiredChecks:   []string{dummyCheckName},
+			openshiftVersion: "4.9",
 		}
 
 		r, err := c.Certify(validChartUri)
@@ -95,10 +96,11 @@ func TestCertifier_Certify(t *testing.T) {
 
 	t.Run("Result should be positive if check exists and returns positive", func(t *testing.T) {
 		c := &certifier{
-			settings:       cli.New(),
-			config:         viper.New(),
-			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks: []string{dummyCheckName},
+			settings:         cli.New(),
+			config:           viper.New(),
+			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{dummyCheckName},
+			openshiftVersion: "4.9",
 		}
 
 		r, err := c.Certify(validChartUri)

--- a/pkg/chartverifier/certifierbuilder.go
+++ b/pkg/chartverifier/certifierbuilder.go
@@ -50,13 +50,14 @@ func DefaultRegistry() checks.Registry {
 }
 
 type certifierBuilder struct {
-	checks      []string
-	config      *viper.Viper
-	overrides   []string
-	registry    checks.Registry
-	toolVersion string
-	values      map[string]interface{}
-	settings    *cli.EnvSettings
+	checks           []string
+	config           *viper.Viper
+	overrides        []string
+	registry         checks.Registry
+	toolVersion      string
+	openshiftVersion string
+	values           map[string]interface{}
+	settings         *cli.EnvSettings
 }
 
 func (b *certifierBuilder) SetSettings(settings *cli.EnvSettings) CertifierBuilder {
@@ -94,6 +95,11 @@ func (b *certifierBuilder) SetToolVersion(version string) CertifierBuilder {
 	return b
 }
 
+func (b *certifierBuilder) SetOpenShiftVersion(version string) CertifierBuilder {
+	b.openshiftVersion = version
+	return b
+}
+
 func (b *certifierBuilder) Build() (Certifier, error) {
 	if len(b.checks) == 0 {
 		return nil, errors.New("no checks have been required")
@@ -118,12 +124,13 @@ func (b *certifierBuilder) Build() (Certifier, error) {
 	}
 
 	return &certifier{
-		config:         b.config,
-		registry:       b.registry,
-		requiredChecks: b.checks,
-		settings:       b.settings,
-		toolVersion:    b.toolVersion,
-		values:         b.values,
+		config:           b.config,
+		registry:         b.registry,
+		requiredChecks:   b.checks,
+		settings:         b.settings,
+		toolVersion:      b.toolVersion,
+		openshiftVersion: b.openshiftVersion,
+		values:           b.values,
 	}, nil
 }
 

--- a/pkg/chartverifier/helmcertifier.go
+++ b/pkg/chartverifier/helmcertifier.go
@@ -29,6 +29,7 @@ type CertifierBuilder interface {
 	SetConfig(config *viper.Viper) CertifierBuilder
 	SetOverrides([]string) CertifierBuilder
 	SetToolVersion(string) CertifierBuilder
+	SetOpenShiftVersion(string) CertifierBuilder
 	SetSettings(settings *cli.EnvSettings) CertifierBuilder
 	Build() (Certifier, error)
 }

--- a/pkg/tool/oc.go
+++ b/pkg/tool/oc.go
@@ -19,9 +19,9 @@ func NewOc(exec exec.ProcessExecutor) Oc {
 
 const osVersionKey = "openshiftVersion"
 
-func (o Oc) GetVersion() (string, error) {
+func (o Oc) GetVersion(ov string) (string, error) {
 	rawOutput, err := o.exec.RunProcessAndCaptureOutput("oc", "version", "-o", "yaml")
-	if err != nil {
+	if err != nil && ov == "" {
 		return "", err
 	}
 	out := map[string]interface{}{}
@@ -32,7 +32,10 @@ func (o Oc) GetVersion() (string, error) {
 
 	version := out[osVersionKey]
 	if version == nil {
-		return "", fmt.Errorf("%q not found in 'oc version' output", osVersionKey)
+		if ov != "" {
+			return ov, nil
+		}
+		return "", fmt.Errorf("%q not found in 'oc version' output.  And the 'openshift-version' flag has not set.", osVersionKey)
 	}
 
 	v, ok := version.(string)

--- a/pkg/tool/oc.go
+++ b/pkg/tool/oc.go
@@ -19,9 +19,9 @@ func NewOc(exec exec.ProcessExecutor) Oc {
 
 const osVersionKey = "openshiftVersion"
 
-func (o Oc) GetVersion(ov string) (string, error) {
+func (o Oc) GetVersion() (string, error) {
 	rawOutput, err := o.exec.RunProcessAndCaptureOutput("oc", "version", "-o", "yaml")
-	if err != nil && ov == "" {
+	if err != nil {
 		return "", err
 	}
 	out := map[string]interface{}{}
@@ -32,10 +32,7 @@ func (o Oc) GetVersion(ov string) (string, error) {
 
 	version := out[osVersionKey]
 	if version == nil {
-		if ov != "" {
-			return ov, nil
-		}
-		return "", fmt.Errorf("%q not found in 'oc version' output.  And the 'openshift-version' flag has not set.", osVersionKey)
+		return "", fmt.Errorf("%q not found in 'oc version' output", osVersionKey)
 	}
 
 	v, ok := version.(string)


### PR DESCRIPTION
The `oc version` command gives the `openshiftVersion` value if the
logged-in user (role) has access to get values of `clusteroperators`
(a cluster scoped resource in the `config.openshift.io` API group).
A developer may not have these kinds of access to run the chart-verifier.

This solution introduces a command-line flag to set the value of
`openshiftVersion`.  The flag is `--openshift-version` (`-V` as a short
option).  If the user has access to get values of `clusteroperators`
resource, that value will get precedence over the CLI flag.

Fixes #111

- [x] Update documentation