### PR TITLE
Correct the logic to derive OS version

### DIFF
--- a/pkg/chartverifier/certifier.go
+++ b/pkg/chartverifier/certifier.go
@@ -82,13 +82,17 @@ func (c *certifier) Certify(uri string) (*Certificate, error) {
 	oc := tool.NewOc(procExec)
 
 	osVersion, err := oc.GetVersion()
-	if err != nil && c.openshiftVersion == "" {
-		return nil, OpenShiftVersionErr(err.Error())
+	if err != nil {
+		if c.openshiftVersion == "" {
+			return nil, OpenShiftVersionErr(err.Error())
+		} else {
+			osVersion = c.openshiftVersion
+		}
 	}
-	if _, err := semver.NewVersion(c.openshiftVersion); err != nil {
+
+	if _, err := semver.NewVersion(osVersion); err != nil {
 		return nil, OpenShiftSemVerErr(err.Error())
 	}
-	osVersion = c.openshiftVersion
 
 	result := NewCertificateBuilder().
 		SetToolVersion(c.toolVersion).

--- a/pkg/chartverifier/certifier_test.go
+++ b/pkg/chartverifier/certifier_test.go
@@ -138,4 +138,12 @@ func TestGetVersion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "4.6.7", v)
 	})
+
+	t.Run("oc version error and empty user input", func(t *testing.T) {
+		errIn := errors.New("error")
+		v, err := getVersion("", "", errIn)
+		require.Error(t, err)
+		require.Equal(t, "", v)
+	})
+
 }

--- a/pkg/chartverifier/certifier_test.go
+++ b/pkg/chartverifier/certifier_test.go
@@ -111,3 +111,31 @@ func TestCertifier_Certify(t *testing.T) {
 
 	cancel()
 }
+
+func TestGetVersion(t *testing.T) {
+	t.Run("oc version error and wrong user input", func(t *testing.T) {
+		errIn := errors.New("error")
+		v, err := getVersion("", "NaN", errIn)
+		require.NoError(t, err)
+		require.Equal(t, "NaN", v)
+	})
+
+	t.Run("oc version error and correct user input", func(t *testing.T) {
+		errIn := errors.New("error")
+		v, err := getVersion("", "4.6.7", errIn)
+		require.NoError(t, err)
+		require.Equal(t, "4.6.7", v)
+	})
+
+	t.Run("oc version and wrong user input", func(t *testing.T) {
+		v, err := getVersion("4.6.7", "NaN", nil)
+		require.NoError(t, err)
+		require.Equal(t, "4.6.7", v)
+	})
+
+	t.Run("oc version and correct user input", func(t *testing.T) {
+		v, err := getVersion("4.6.7", "5.9.1", nil)
+		require.NoError(t, err)
+		require.Equal(t, "4.6.7", v)
+	})
+}

--- a/pkg/chartverifier/certifierbuilder.go
+++ b/pkg/chartverifier/certifierbuilder.go
@@ -122,7 +122,7 @@ func (b *certifierBuilder) Build() (Certifier, error) {
 		parts := strings.Split(val, "=")
 		b.config.Set(parts[0], parts[1])
 	}
-
+	ver := &version{}
 	return &certifier{
 		config:           b.config,
 		registry:         b.registry,
@@ -131,6 +131,7 @@ func (b *certifierBuilder) Build() (Certifier, error) {
 		toolVersion:      b.toolVersion,
 		openshiftVersion: b.openshiftVersion,
 		values:           b.values,
+		version:          ver,
 	}, nil
 }
 


### PR DESCRIPTION
There are a couple of issues with the current logic:

1. In the current logic, if the `oc version` provides a valid server version, the checking for SemVer spec was still performed against the user input value.

2. In the current logic, if the `oc version` provides a valid server version, also there is a valid user input value, then the user input value was used.  It is against the expected behavior.  The `oc version` value should have priority over user input.
