### PR TITLE
[DO-NOT-MERGE] Document adding OpenShift Version in the Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For more information see:
 - [Annotations in the report, tool and submitter provided.](docs/helm-chart-annotations.md)
 - [Introduction to the submission process.](docs/helm-chart-submission.md)
 - [Problems with the report? Try the trouble shooting guide.](docs/helm-chart-troubleshooting.md)
+- [OpenShift Version in the Report](docs/openshift-version-in-the-report.md)
 
 For Developer specific information see:
 

--- a/docs/openshift-version-in-the-report.md
+++ b/docs/openshift-version-in-the-report.md
@@ -52,13 +52,13 @@ subjects:
 ```
 
 You can replace the name of the ServiceAccount and its namespace values in the
-above example. Note: Instead of a service account, the [subject could be a user
+above example.  Note: Instead of a service account, the [subject could be a user
 or group][subject].
 
 If giving the role mentioned above is not feasible, alternatively, you can
-specify the OpenShift version as a command-line flag in the chart-verifier
-tool. You can use the `--openshift-version` flag to specify the version. Here is
-an example:
+specify the OpenShift version as a command-line flag in the chart-verifier tool.
+You can use the `--openshift-version` flag to specify the version.  Here is an
+example:
 
 ```
 $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify --openshift-version=4.9.2 <chart-uri>

--- a/docs/openshift-version-in-the-report.md
+++ b/docs/openshift-version-in-the-report.md
@@ -1,9 +1,10 @@
 # OpenShift Version in the Report
 
-The chart-verifier tool adds the OpenShift version where chart-testing has run
+The chart-verifier CLI tool adds the OpenShift version where chart-testing has run
 in the report.  The information is available as a metadata at this path:
-`.metadata.tool.certifiedOpenShiftVersions`.  Here is an example showing only
-the relevant details:
+`.metadata.tool.certifiedOpenShiftVersions`.
+
+**Example**
 
 ```
 ...
@@ -12,13 +13,14 @@ metadata:
     certifiedOpenShiftVersions: 4.7.8
 ```
 
-The chart-verifier tool runs the `oc version -o yaml` command to retrieve the
-OpenShift version value.  It gives the version value if the logged-in user
-(role) has access to `get` values of `clusteroperators` (a cluster scoped
-resource in the `config.openshift.io` API group).  You need to configure a
-specific role for the user, as given here.
+The chart-verifier CLI tool runs the `oc version -o yaml` command to retrieve
+the value of the OpenShift version.  The `oc version` command gives the version
+value if the logged-in user (role) has access to `get` values of
+`clusteroperators` (a cluster scoped resource in the `config.openshift.io` API
+group).  You need to configure a specific role (ClusterRole) for the user, as
+shown in the following example:
 
-You need a ClusterRole like this:
+**Example of a ClusterRole**
 
 ```
 kind: ClusterRole
@@ -34,7 +36,7 @@ rules:
       - 'get'
 ```
 
-And ClusterRoleBinding like this:
+**Example of a ClusterRoleBinding**
 
 ```
 kind: ClusterRoleBinding
@@ -51,20 +53,27 @@ subjects:
     namespace: <SERVICE-ACCOUNT-NAMESPACE>
 ```
 
-You can replace the name of the ServiceAccount and its namespace values in the
-above example.  Note: Instead of a service account, the [subject could be a user
-or group][subject].
+**Notes:**
 
-If giving the role mentioned above is not feasible, alternatively, you can
-specify the OpenShift version as a command-line flag in the chart-verifier tool.
-You can use the `--openshift-version` flag to specify the version.  Here is an
-example:
+1. You can replace values of the name and namespace of the ServiceAccount in the
+   previous example.
+2. Instead of a service account, the [subject could be a user or
+   group][subject].
+
+ If configuring the role as mentioned in the previous examples is not feasible,
+alternatively, you can specify the OpenShift version as a command-line flag in
+the chart-verifier CLI tool.
+
+For example, you can use the `--openshift-version` flag to specify the OpenShift
+version in the chart-verifier CLI tool:
 
 ```
 $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify --openshift-version=4.9.2 <chart-uri>
 ```
 
-The `-V` flag is the short version for the `--openshift-version` flag.
+Note: The `-V` flag is the short version for the `--openshift-version` flag.
+
+**Example**
 
 ```
 $ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -V 4.9.2 <chart-uri>

--- a/docs/openshift-version-in-the-report.md
+++ b/docs/openshift-version-in-the-report.md
@@ -1,0 +1,73 @@
+# OpenShift Version in the Report
+
+The chart-verifier tool adds the OpenShift version where chart-testing has run
+in the report.  The information is available as a metadata at this path:
+`.metadata.tool.certifiedOpenShiftVersions`.  Here is an example showing only
+the relevant details:
+
+```
+...
+metadata:
+  tool:
+    certifiedOpenShiftVersions: 4.7.8
+```
+
+The chart-verifier tool runs the `oc version -o yaml` command to retrieve the
+OpenShift version value.  It gives the version value if the logged-in user
+(role) has access to `get` values of `clusteroperators` (a cluster scoped
+resource in the `config.openshift.io` API group).  You need to configure a
+specific role for the user, as given here.
+
+You need a ClusterRole like this:
+
+```
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chart-verifier-cluster-operator-role
+rules:
+  - apiGroups:
+      - "config.openshift.io"
+    resources:
+      - 'clusteroperators'
+    verbs:
+      - 'get'
+```
+
+And ClusterRoleBinding like this:
+
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: chart-verifier-cluster-operator-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chart-verifier-cluster-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: <SERVICE-ACCOUNT-NAME>
+    namespace: <SERVICE-ACCOUNT-NAMESPACE>
+```
+
+You can replace the name of the ServiceAccount and its namespace values in the
+above example. Note: Instead of a service account, the [subject could be a user
+or group][subject].
+
+If giving the role mentioned above is not feasible, alternatively, you can
+specify the OpenShift version as a command-line flag in the chart-verifier
+tool. You can use the `--openshift-version` flag to specify the version. Here is
+an example:
+
+```
+$ podman run -it --rm quay.io/redhat-certification/chart-verifier verify --openshift-version=4.9.2 <chart-uri>
+```
+
+The `-V` flag is the short version for the `--openshift-version` flag.
+
+```
+$ podman run -it --rm quay.io/redhat-certification/chart-verifier verify -V 4.9.2 <chart-uri>
+```
+
+[subject]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects


### PR DESCRIPTION
The chart-verifier tool adds the OpenShift version where chart-testing has run in the report.