### PR TITLE
Add OpenShift version if chart-testing is enabled

### DIFF
--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -20,7 +20,7 @@ import (
 // Versioner provides OpenShift version
 type Versioner func() (string, error)
 
-var getVersion = func() (string, error) {
+func getVersion() (string, error) {
 
 	procExec := exec.NewProcessExecutor(false)
 	oc := tool.NewOc(procExec)

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -21,7 +21,7 @@ type Versioner func() (string, error)
 
 func getVersion() (string, error) {
 
-	procExec := exec.NewProcessExecutor(false)
+	procExec := tool.NewProcessExecutor(false)
 	oc := tool.NewOc(procExec)
 
 	// oc.GetVersion() returns an error both in case the oc command can't be executed and

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"errors"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -116,4 +117,87 @@ func TestChartTesting(t *testing.T) {
 			require.Contains(t, r.Reason, "executing helm with args")
 		})
 	}
+}
+
+type ocVersionError struct{}
+
+func (v ocVersionError) getVersion() (string, error) {
+	return "", errors.New("error")
+}
+
+type ocVersionWithoutError struct {
+	Version string
+}
+
+func (v ocVersionWithoutError) getVersion() (string, error) {
+	return v.Version, nil
+}
+
+type testAnnotationHolder struct {
+	OpenShiftVersion              string
+	CertifiedOpenShiftVersionFlag string
+}
+
+func (holder *testAnnotationHolder) SetCertifiedOpenShiftVersion(version string) {
+	holder.OpenShiftVersion = version
+}
+
+func (holder *testAnnotationHolder) GetCertifiedOpenShiftVersionFlag() string {
+	return holder.CertifiedOpenShiftVersionFlag
+}
+
+func TestVersionSetting(t *testing.T) {
+	type testCase struct {
+		description string
+		holder      *testAnnotationHolder
+		versioner   Versioner
+		version     string
+		error       string
+	}
+
+	testCases := []testCase{
+		{
+			description: "oc.Version returns 4.7.9",
+			holder:      &testAnnotationHolder{},
+			versioner:   ocVersionWithoutError{Version: "4.7.9"},
+			version:     "4.7.9",
+		},
+		{
+			description: "oc.Version returns error, flag set to 4.7.8",
+			holder:      &testAnnotationHolder{CertifiedOpenShiftVersionFlag: "4.7.8"},
+			versioner:   ocVersionError{},
+			version:     "4.7.8",
+		},
+		{
+			description: "oc.Version returns semantic error, flag set to fourseveneight",
+			holder:      &testAnnotationHolder{CertifiedOpenShiftVersionFlag: "fourseveneight"},
+			versioner:   ocVersionError{},
+			error:       "OpenShift version is not following SemVer spec. Invalid Semantic Version",
+		},
+		{
+			description: "oc.Version returns error, flag not set",
+			holder:      &testAnnotationHolder{},
+			versioner:   ocVersionError{},
+			error:       "Missing OpenShift version. error. And the 'openshift-version' flag has not set.",
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.description, func(t *testing.T) {
+
+			err := setOCVersion(&CheckOptions{AnnotationHolder: tc.holder}, tc.versioner)
+
+			if len(tc.error) > 0 {
+				require.Error(t, err)
+				require.Equal(t, tc.error, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.version, tc.holder.OpenShiftVersion)
+			}
+
+		})
+
+	}
+
 }

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -119,11 +119,11 @@ func TestChartTesting(t *testing.T) {
 	}
 }
 
-var getVersionError = func() (string, error) {
+func getVersionError() (string, error) {
 	return "", errors.New("error")
 }
 
-var getVersionGood = func() (string, error) {
+func getVersionGood() (string, error) {
 	return "4.7.9", nil
 }
 

--- a/pkg/chartverifier/checks/registry.go
+++ b/pkg/chartverifier/checks/registry.go
@@ -51,6 +51,11 @@ func (r *Result) AddResult(outcome bool, reason string) Result {
 	return *r
 }
 
+type AnnotationHolder interface {
+	SetCertifiedOpenShiftVersion(version string)
+	GetCertifiedOpenShiftVersionFlag() string
+}
+
 type CheckType string
 
 type Check struct {
@@ -70,6 +75,8 @@ type CheckOptions struct {
 	Values map[string]interface{}
 	// HelmEnvSettings contains the Helm related environment settings.
 	HelmEnvSettings *helmcli.EnvSettings
+	// AnnotationHolder provides and API to set the OpenShift Version
+	AnnotationHolder AnnotationHolder
 }
 
 type CheckFunc func(options *CheckOptions) (Result, error)

--- a/pkg/chartverifier/verifier.go
+++ b/pkg/chartverifier/verifier.go
@@ -38,11 +38,6 @@ func NewCheckErr(err error) error {
 	return CheckErr(err.Error())
 }
 
-// Versioner provides OpenShift version
-type Versioner interface {
-	getVersion(debug bool) (string, error)
-}
-
 type AnnotationHolder struct {
 	Holder                        ReportBuilder
 	CertifiedOpenShiftVersionFlag string

--- a/pkg/chartverifier/verifier_test.go
+++ b/pkg/chartverifier/verifier_test.go
@@ -139,12 +139,14 @@ func TestVerifier_Verify(t *testing.T) {
 		require.True(t, r.isOk())
 	})
 
+	chartTestingCheckName := "chart-testing"
+
 	t.Run("oc version error and wrong user input", func(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
+			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{chartTestingCheckName},
 			openshiftVersion: "NaN",
 			version:          verocVersionError,
 		}
@@ -157,8 +159,8 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
+			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{chartTestingCheckName},
 			openshiftVersion: "4.9.7",
 			version:          verocVersionError,
 		}
@@ -174,8 +176,8 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
+			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{chartTestingCheckName},
 			openshiftVersion: "NaN",
 			version:          verocVersionWithoutError,
 		}
@@ -191,8 +193,8 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
+			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{chartTestingCheckName},
 			openshiftVersion: "5.6.8",
 			version:          verocVersionWithoutError,
 		}
@@ -208,8 +210,8 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
+			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{chartTestingCheckName},
 			openshiftVersion: "",
 			version:          verocVersionError,
 		}
@@ -217,6 +219,36 @@ func TestVerifier_Verify(t *testing.T) {
 		r, err := c.Verify(validChartUri)
 		require.Error(t, err)
 		require.Nil(t, r)
+	})
+
+	t.Run("dummy-check oc version error and wrong user input", func(t *testing.T) {
+		c := &verifier{
+			settings:         cli.New(),
+			config:           viper.New(),
+			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{dummyCheckName},
+			openshiftVersion: "NaN",
+			version:          verocVersionError,
+		}
+		r, err := c.Verify(validChartUri)
+		require.Error(t, err)
+		require.Nil(t, r)
+	})
+
+	t.Run("dummy-check oc version error and empty user input", func(t *testing.T) {
+		c := &verifier{
+			settings:         cli.New(),
+			config:           viper.New(),
+			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks:   []string{dummyCheckName},
+			openshiftVersion: "",
+			version:          verocVersionError,
+		}
+		r, err := c.Verify(validChartUri)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+		require.True(t, r.isOk())
+		require.Equal(t, "", r.Metadata.ToolMetadata.CertifiedOpenShiftVersions)
 	})
 
 	cancel()

--- a/pkg/chartverifier/verifier_test.go
+++ b/pkg/chartverifier/verifier_test.go
@@ -29,18 +29,6 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/testutil"
 )
 
-type ocVersionError struct{}
-
-func (v *ocVersionError) getVersion(debug bool) (string, error) {
-	return "", errors.New("error")
-}
-
-type ocVersionWithoutError struct{}
-
-func (v *ocVersionWithoutError) getVersion(debug bool) (string, error) {
-	return "4.9.7", nil
-}
-
 func (c *Report) isOk() bool {
 	outcome := true
 	for _, check := range c.Results {
@@ -75,16 +63,12 @@ func TestVerifier_Verify(t *testing.T) {
 
 	validChartUri := "http://" + addr + "/charts/chart-0.1.0-v3.valid.tgz"
 
-	verocVersionWithoutError := &ocVersionWithoutError{}
-	verocVersionError := &ocVersionError{}
-
 	t.Run("Should return error if check does not exist", func(t *testing.T) {
 		c := &verifier{
 			settings:       cli.New(),
 			config:         viper.New(),
 			registry:       checks.NewRegistry(),
 			requiredChecks: []string{dummyCheckName},
-			version:        verocVersionWithoutError,
 		}
 
 		r, err := c.Verify(validChartUri)
@@ -98,7 +82,6 @@ func TestVerifier_Verify(t *testing.T) {
 			config:         viper.New(),
 			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: erroredCheck}),
 			requiredChecks: []string{dummyCheckName},
-			version:        verocVersionWithoutError,
 		}
 
 		r, err := c.Verify(validChartUri)
@@ -114,7 +97,6 @@ func TestVerifier_Verify(t *testing.T) {
 			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: negativeCheck}),
 			requiredChecks:   []string{dummyCheckName},
 			openshiftVersion: "4.9",
-			version:          verocVersionWithoutError,
 		}
 
 		r, err := c.Verify(validChartUri)
@@ -125,130 +107,16 @@ func TestVerifier_Verify(t *testing.T) {
 
 	t.Run("Result should be positive if check exists and returns positive", func(t *testing.T) {
 		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
-			openshiftVersion: "4.9",
-			version:          verocVersionWithoutError,
+			settings:       cli.New(),
+			config:         viper.New(),
+			registry:       checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
+			requiredChecks: []string{dummyCheckName},
 		}
 
 		r, err := c.Verify(validChartUri)
 		require.NoError(t, err)
 		require.NotNil(t, r)
 		require.True(t, r.isOk())
-	})
-
-	chartTestingCheckName := "chart-testing"
-
-	t.Run("oc version error and wrong user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{chartTestingCheckName},
-			openshiftVersion: "NaN",
-			version:          verocVersionError,
-		}
-		r, err := c.Verify(validChartUri)
-		require.Error(t, err)
-		require.Nil(t, r)
-	})
-
-	t.Run("oc version error and correct user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{chartTestingCheckName},
-			openshiftVersion: "4.9.7",
-			version:          verocVersionError,
-		}
-
-		r, err := c.Verify(validChartUri)
-		require.NoError(t, err)
-		require.NotNil(t, r)
-		require.True(t, r.isOk())
-		require.Equal(t, "4.9.7", r.Metadata.ToolMetadata.CertifiedOpenShiftVersions)
-	})
-
-	t.Run("oc version and wrong user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{chartTestingCheckName},
-			openshiftVersion: "NaN",
-			version:          verocVersionWithoutError,
-		}
-
-		r, err := c.Verify(validChartUri)
-		require.NoError(t, err)
-		require.NotNil(t, r)
-		require.True(t, r.isOk())
-		require.Equal(t, "4.9.7", r.Metadata.ToolMetadata.CertifiedOpenShiftVersions)
-	})
-
-	t.Run("oc version and correct user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{chartTestingCheckName},
-			openshiftVersion: "5.6.8",
-			version:          verocVersionWithoutError,
-		}
-
-		r, err := c.Verify(validChartUri)
-		require.NoError(t, err)
-		require.NotNil(t, r)
-		require.True(t, r.isOk())
-		require.Equal(t, "4.9.7", r.Metadata.ToolMetadata.CertifiedOpenShiftVersions)
-	})
-
-	t.Run("oc version error and empty user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: chartTestingCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{chartTestingCheckName},
-			openshiftVersion: "",
-			version:          verocVersionError,
-		}
-
-		r, err := c.Verify(validChartUri)
-		require.Error(t, err)
-		require.Nil(t, r)
-	})
-
-	t.Run("dummy-check oc version error and wrong user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
-			openshiftVersion: "NaN",
-			version:          verocVersionError,
-		}
-		r, err := c.Verify(validChartUri)
-		require.Error(t, err)
-		require.Nil(t, r)
-	})
-
-	t.Run("dummy-check oc version error and empty user input", func(t *testing.T) {
-		c := &verifier{
-			settings:         cli.New(),
-			config:           viper.New(),
-			registry:         checks.NewRegistry().Add(checks.Check{Name: dummyCheckName, Type: MandatoryCheckType, Func: positiveCheck}),
-			requiredChecks:   []string{dummyCheckName},
-			openshiftVersion: "",
-			version:          verocVersionError,
-		}
-		r, err := c.Verify(validChartUri)
-		require.NoError(t, err)
-		require.NotNil(t, r)
-		require.True(t, r.isOk())
-		require.Equal(t, "", r.Metadata.ToolMetadata.CertifiedOpenShiftVersions)
 	})
 
 	cancel()

--- a/pkg/chartverifier/verifierbuilder.go
+++ b/pkg/chartverifier/verifierbuilder.go
@@ -122,7 +122,6 @@ func (b *verifierBuilder) Build() (Vertifier, error) {
 		parts := strings.Split(val, "=")
 		b.config.Set(parts[0], parts[1])
 	}
-	ver := &version{}
 	return &verifier{
 		config:           b.config,
 		registry:         b.registry,
@@ -131,7 +130,6 @@ func (b *verifierBuilder) Build() (Vertifier, error) {
 		toolVersion:      b.toolVersion,
 		openshiftVersion: b.openshiftVersion,
 		values:           b.values,
-		version:          ver,
 	}, nil
 }
 

--- a/pkg/tool/oc.go
+++ b/pkg/tool/oc.go
@@ -17,7 +17,18 @@ func NewOc(exec exec.ProcessExecutor) Oc {
 	}
 }
 
-const osVersionKey = "openshiftVersion"
+const osVersionKey = "serverVersion"
+
+// Based on https://access.redhat.com/solutions/4870701
+var kubeOpenShiftVersionMap map[string]string = map[string]string{
+	"1.20": "4.7.0",
+	"1.19": "4.6.0",
+	"1.18": "4.5.0",
+	"1.17": "4.4.0",
+	"1.16": "4.3.0",
+	"1.14": "4.2.0",
+	"1.13": "4.1.0",
+}
 
 func (o Oc) GetVersion() (string, error) {
 	rawOutput, err := o.exec.RunProcessAndCaptureOutput("oc", "version", "-o", "yaml")
@@ -29,16 +40,14 @@ func (o Oc) GetVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	version := out[osVersionKey]
-	if version == nil {
-		return "", fmt.Errorf("%q not found in 'oc version' output", osVersionKey)
-	}
-
-	v, ok := version.(string)
+	// Relying on Kubernetes version can be replaced after fixing this issue:
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1850656
+	kubeServerVersion := out[osVersionKey].(map[string]string)
+	kubeVersion := kubeServerVersion["major"] + "." + kubeServerVersion["minor"]
+	osVersion, ok := kubeOpenShiftVersionMap[kubeVersion]
 	if !ok {
-		return "", fmt.Errorf("%q does not contain a string: %v", osVersionKey, version)
+		return "", fmt.Errorf("Internal error: %q not found in Kubernetes-OpenShift version map", kubeVersion)
 	}
 
-	return v, nil
+	return osVersion, nil
 }


### PR DESCRIPTION
* Ensure the OpenShift version is available if the chart-testing
  check is enabled.

* Users should be able to run a check that doesn't require a cluster.

* If the user inputs an OpenShift version that should be a valid
  SemVer version.

Fixes #129
Jira: https://issues.redhat.com/browse/HELM-188