### PR TITLE
Make chart-testing check honor values informed through `--chart-set`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/helm/chart-testing/v3 v3.3.1
+	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/helm/chart-testing/v3 v3.3.1
-	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/imdario/mergo v0.3.11
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -235,10 +235,10 @@ func readObjectFromYamlFile(filename string) (map[string]interface{}, error) {
 	return obj, nil
 }
 
-// writeObjectToTempYamlFile writes the given obj into a temporary file.
+// writeObjectToTempYamlFile writes the given obj into a temporary file and returns its location, 
 //
 // It is responsibility of the caller to discard the file when finished using it.
-func writeObjectToTempYamlFile(obj map[string]interface{}) (string, func(), error) {
+func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cleanupFunc func(), err error) {
 	objBytes, err := yaml.Marshal(obj)
 	if err != nil {
 		return "", nil, fmt.Errorf("marshalling values file new contents: %w", err)
@@ -249,18 +249,18 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (string, func(), erro
 		return "", nil, fmt.Errorf("creating temporary directory: %w", err)
 	}
 
-	filename := path.Join(tempDir, "values.yaml")
+	filename = path.Join(tempDir, "values.yaml")
 
 	err = ioutil.WriteFile(filename, objBytes, fs.ModeExclusive)
 	if err != nil {
 		return "", nil, fmt.Errorf("writing values file new contents: %w", err)
 	}
 
-	cleanTempDir := func() {
+	cleanupFunc = func() {
 		os.RemoveAll(tempDir)
 	}
 
-	return filename, cleanTempDir, nil
+	return filename, cleanupFunc, nil
 }
 
 // newTempValuesFileWithOverrides applies the extra values provided into the given filename (a YAML file) and materializes its

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -2,7 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -251,7 +250,7 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cle
 
 	filename = path.Join(tempDir, "values.yaml")
 
-	err = ioutil.WriteFile(filename, objBytes, fs.ModeExclusive)
+	err = ioutil.WriteFile(filename, objBytes, 0644)
 	if err != nil {
 		return "", nil, fmt.Errorf("writing values file new contents: %w", err)
 	}

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -234,7 +234,7 @@ func readObjectFromYamlFile(filename string) (map[string]interface{}, error) {
 	return obj, nil
 }
 
-// writeObjectToTempYamlFile writes the given obj into a temporary file and returns its location, 
+// writeObjectToTempYamlFile writes the given obj into a temporary file and returns its location,
 //
 // It is responsibility of the caller to discard the file when finished using it.
 func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cleanupFunc func(), err error) {
@@ -272,7 +272,7 @@ func newTempValuesFileWithOverrides(filename string, valuesOverrides map[string]
 	var obj map[string]interface{}
 
 	if filename != "" {
-        // in the case a filename is provided, read its contents and merge any available values override.
+		// in the case a filename is provided, read its contents and merge any available values override.
 		obj, err := readObjectFromYamlFile(filename)
 		if err != nil {
 			return "", nil, fmt.Errorf("reading values file: %w", err)

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -322,7 +322,7 @@ func installAndTestChartRelease(
 		// and be executed in reverse order after the loop.
 		fun := func() error {
 
-			tempValuesFile, tmpValuesFileCleanup, err := newTempValuesFileWithOverrides(valuesFile, valuesOverrides)
+			tmpValuesFile, tmpValuesFileCleanup, err := newTempValuesFileWithOverrides(valuesFile, valuesOverrides)
 			if err != nil {
 				// it is required this operation to succeed, otherwise there are no guarantees the values informed using
 				// `--chart-set` are propagated to the installation process, so the process breaks here.
@@ -333,7 +333,7 @@ func installAndTestChartRelease(
 			namespace, release, releaseSelector, releaseCleanup := generateInstallConfig(cfg, chrt, helm, kubectl)
 			defer releaseCleanup()
 
-			if err := helm.InstallWithValues(chrt.Path(), tempValuesFile, namespace, release); err != nil {
+			if err := helm.InstallWithValues(chrt.Path(), tmpValuesFile, namespace, release); err != nil {
 				return err
 			}
 			return testRelease(helm, kubectl, release, namespace, releaseSelector, false)

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -7,7 +7,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/cli"
 )
 
 // absPathFromSourceFileLocation returns the absolute path of a file or directory under the current source file's
@@ -17,12 +19,12 @@ func absPathFromSourceFileLocation(name string) (string, error) {
 	if !ok {
 		panic("couldn't get current path")
 	}
-    filename, err := filepath.Abs(filename)
-    if err != nil {
-        return "", fmt.Errorf("retrieving current source file's location: %w", err)
-    }
-    dirname := path.Dir(filename)
-    return filepath.Join(dirname, name), nil
+	filename, err := filepath.Abs(filename)
+	if err != nil {
+		return "", fmt.Errorf("retrieving current source file's location: %w", err)
+	}
+	dirname := path.Dir(filename)
+	return filepath.Join(dirname, name), nil
 }
 
 func TestChartTesting(t *testing.T) {
@@ -32,19 +34,21 @@ func TestChartTesting(t *testing.T) {
 		opts        CheckOptions
 	}
 
-    chartUri, err := absPathFromSourceFileLocation("chart-0.1.0-v3.valid.tgz")
-    if err != nil {
-        t.Error(err)
-    }
+	chartUri, err := absPathFromSourceFileLocation("psql-service-0.1.7")
+	if err != nil {
+		t.Error(err)
+	}
 
 	positiveTestCases := []testCase{
 		{
-			description: "with license=true value override",
+			description: "providing a valid k8Project value should succeed",
 			opts: CheckOptions{
 				URI: chartUri,
 				Values: map[string]interface{}{
-					"license": true,
+					"k8Project": "default",
 				},
+				ViperConfig:     viper.New(),
+				HelmEnvSettings: cli.New(),
 			},
 		},
 	}
@@ -60,10 +64,14 @@ func TestChartTesting(t *testing.T) {
 
 	negativeTestCases := []testCase{
 		{
-			description: "with chart-testing defaults",
+			description: "providing a bogus k8Project should fail",
 			opts: CheckOptions{
 				URI: chartUri,
-				Values: map[string]interface{}{},
+				Values: map[string]interface{}{
+					"k8Project": "bogus",
+				},
+				ViperConfig:     viper.New(),
+				HelmEnvSettings: cli.New(),
 			},
 		},
 	}
@@ -71,9 +79,10 @@ func TestChartTesting(t *testing.T) {
 	for _, tc := range negativeTestCases {
 		t.Run(tc.description, func(t *testing.T) {
 			r, err := ChartTesting(&tc.opts)
-			require.Error(t, err)
 			require.NotNil(t, r)
 			require.False(t, r.Ok)
+			require.NoError(t, err)
+			require.Contains(t, r.Reason, "executing helm with args")
 		})
 	}
 }

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -39,6 +40,10 @@ func lookPath(programs ...string) error {
 }
 
 func TestChartTesting(t *testing.T) {
+	if os.Getenv("CHART_VERIFIER_ENABLE_CLUSTER_TESTING") == "" {
+		t.Skip("CHART_VERIFIER_ENABLE_CLUSTER_TESTING not set, skipping in cluster tests")
+	}
+
 	if err := lookPath("helm", "kubectl"); err != nil {
 		t.Skip(err.Error())
 	}

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -94,6 +94,17 @@ func TestChartTesting(t *testing.T) {
 				HelmEnvSettings: cli.New(),
 			},
 		},
+		{
+			// the chart being used in this test forces the rendered resources to have an empty namespace field, which
+			// is invalid and can't be overriden using helm's namespace option.
+			description: "empty values should fail",
+			opts: CheckOptions{
+				URI:             chartUri,
+				Values:          map[string]interface{}{},
+				ViperConfig:     viper.New(),
+				HelmEnvSettings: cli.New(),
+			},
+		},
 	}
 
 	for _, tc := range negativeTestCases {

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -58,6 +58,7 @@ func TestChartTesting(t *testing.T) {
 			r, err := ChartTesting(&tc.opts)
 			require.NoError(t, err)
 			require.NotNil(t, r)
+			require.Equal(t, ChartTestingSuccess, r.Reason)
 			require.True(t, r.Ok)
 		})
 	}

--- a/pkg/chartverifier/checks/charttesting_test.go
+++ b/pkg/chartverifier/checks/charttesting_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -27,7 +28,20 @@ func absPathFromSourceFileLocation(name string) (string, error) {
 	return filepath.Join(dirname, name), nil
 }
 
+func lookPath(programs ...string) error {
+	for _, p := range programs {
+		_, err := exec.LookPath(p)
+		if err != nil {
+			return fmt.Errorf("required program %q not found", p)
+		}
+	}
+	return nil
+}
+
 func TestChartTesting(t *testing.T) {
+	if err := lookPath("helm", "kubectl"); err != nil {
+		t.Skip(err.Error())
+	}
 
 	type testCase struct {
 		description string

--- a/pkg/chartverifier/checks/psql-service-0.1.7/.helmignore
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/chartverifier/checks/psql-service-0.1.7/Chart.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/Chart.yaml
@@ -1,0 +1,12 @@
+annotations:
+  charts.openshift.io/archs: x86_64
+  charts.openshift.io/name: PSQL RedHat Demo Chart
+  charts.openshift.io/provider: RedHat
+  charts.openshift.io/supportURL: https://github.com/dperaza4dustbit/helm-chart
+apiVersion: v2
+appVersion: 10.0.0
+description: A Helm chart for a RedHat Certified PSQL
+kubeVersion: 1.20.0
+name: psql-service
+type: application
+version: 0.1.7

--- a/pkg/chartverifier/checks/psql-service-0.1.7/README.md
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/README.md
@@ -1,0 +1,1 @@
+Helm chart for psql 10 certified image

--- a/pkg/chartverifier/checks/psql-service-0.1.7/runtime_value.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/runtime_value.yaml
@@ -1,0 +1,5 @@
+serviceAccount:
+  enabled: true
+  name: sa-with-anyuid
+
+postgresqlPassword: quebolasere

--- a/pkg/chartverifier/checks/psql-service-0.1.7/templates/_helpers.tpl
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ssm-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ssm-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ssm-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ssm-service.labels" -}}
+helm.sh/chart: {{ include "ssm-service.chart" . }}
+{{ include "ssm-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ssm-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ssm-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ssm-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ssm-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/pkg/chartverifier/checks/psql-service-0.1.7/templates/deployment.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.k8Name }}
+  namespace: {{ .Values.k8Project }}
+  annotations:
+      app.kubernetes.io/part-of: ssm
+spec:
+  selector:
+    matchLabels: 
+      app: {{ .Values.k8Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
+      labels:
+        app: {{ .Values.k8Name }}
+        phase: test
+    spec:
+      # securityContext:
+      #   runAsUser: {{ .Values.securityContext.runAsUser }}
+      #   fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+      # serviceAccount: {{ .Values.serviceAccount }}
+      containers:
+      - name: {{ .Values.k8Name }}
+        image: '{{ .Values.image.repository }}{{ .Values.image.name }}:{{ .Values.image.tag }}'
+        env:
+        - name: POSTGRESQL_USER
+          value: {{ .Values.config.postgresUser }}
+        - name: POSTGRESQL_PASSWORD
+          value: {{ .Values.config.postgresPassword }}
+        - name: POSTGRESQL_DATABASE
+          value: {{ .Values.config.postgresDatabase }}
+        - name: CHART_VERSION
+          value: {{ .Chart.AppVersion }}
+        ports:
+          - containerPort: {{ .Values.service.port }}
+        securityContext:
+          runAsNonRoot: true
+        resources:
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
+          requests:
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+

--- a/pkg/chartverifier/checks/psql-service-0.1.7/templates/service.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.k8ServiceName }}
+  namespace: {{ .Values.k8Project }}
+spec:
+  type: {{ .Values.service.type }}
+  # loadBalancerSourceRanges:
+  #   - {{ .Values.service.sourceRange }}
+  ports:
+    - name: rest
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ .Values.k8Name }}

--- a/pkg/chartverifier/checks/psql-service-0.1.7/templates/tests/test-psql-connection.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/templates/tests/test-psql-connection.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-credentials-test"
+  #namespace: {{ .Values.k8Project }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  #serviceAccount: {{ .Values.serviceAccount }}
+  containers:
+    - name: {{ .Release.Name }}-credentials-test
+      image: '{{ .Values.image.repository }}{{ .Values.image.name }}:{{ .Values.image.tag }}'
+      imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+      env:
+        - name: POSTGRESQL_USER
+          value: {{ .Values.config.postgresUser }}
+        - name: PGPASSWORD
+          value: {{ .Values.config.postgresPassword }}
+        - name: POSTGRESQL_DATABASE
+          value: {{ .Values.config.postgresDatabase }}
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          psql -d $POSTGRESQL_DATABASE -h psql -p $PSQL_SERVICE_PORT -U $POSTGRESQL_USER -c "select 1"
+  restartPolicy: Never

--- a/pkg/chartverifier/checks/psql-service-0.1.7/values.schema.json
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/values.schema.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "required": [
+      "image",
+      "k8Project",
+      "config"
+    ],
+    "properties": {
+      "image": {
+        "type": "object",
+        "required": [
+          "name",
+          "repository",
+          "pullPolicy"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+          },
+          "repository": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_./]+$"
+          },
+          "pullPolicy": {
+            "type": "string",
+            "pattern": "^(Always|Never|IfNotPresent)$"
+          }
+        }
+      },
+      "k8Project": {
+        "type": "string",
+        "pattern": "^[a-z0-9-_]+$"
+      },
+      "config": {
+        "type": "object",
+        "required": [
+          "postgresUser",
+          "postgresPassword",
+          "postgresDatabase"
+        ],
+        "properties": {
+          "postgresUser": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+          },
+          "postgresPassword": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+          },
+          "postgresDatabase": {
+            "type": "string",
+            "pattern": "^[a-z0-9-_]+$"
+          }
+        }
+      }     
+    }   
+  }

--- a/pkg/chartverifier/checks/psql-service-0.1.7/values.yaml
+++ b/pkg/chartverifier/checks/psql-service-0.1.7/values.yaml
@@ -1,0 +1,42 @@
+# Default values for ssm-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+k8Project: ""
+k8Name: psql-bee
+k8ServiceName: psql
+
+serviceAccount: sa-with-anyuid
+
+config:
+  postgresUser: dperaza
+  postgresPassword: quebolasere
+  postgresDatabase: helmrocks
+
+image:
+  name: postgresql-10-rhel7
+  repository: "registry.access.redhat.com/rhscl/"
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+
+podSecurityContext: 
+  fsGroup: 2000
+
+securityContext:
+  runAsUser: 1000
+  
+
+service:
+  type: ClusterIP
+  port: 5432
+  sourceRange: 0.0.0.0/0
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -1,6 +1,9 @@
 package tool
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/helm/chart-testing/v3/pkg/tool"
 )
@@ -27,9 +30,12 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 		values = []string{"--values", valuesFile}
 	}
 
-	if _, err := h.RunProcessAndCaptureOutput("helm", "install", release, chart, "--namespace", namespace,
-		"--wait", values, h.extraArgs); err != nil {
-		return err
+	helmInstallArgs := []string{"install", release, chart, "--namespace", namespace, "--wait"}
+	helmInstallArgs = append(helmInstallArgs, values...)
+	helmInstallArgs = append(helmInstallArgs, h.extraArgs...)
+
+	if _, err := h.RunProcessAndCaptureOutput("helm", helmInstallArgs); err != nil {
+		return fmt.Errorf("executing helm with args %q: %w", strings.Join(helmInstallArgs, " "), err)
 	}
 
 	return nil


### PR DESCRIPTION
This change list adjusts the `chart-testing` check to propagate the
values informed by the user through `--chart-set` and friends by
merging those values into the `values.yaml` file for the test context.

- [x] Basic implementation
- [x] Make sure `--chart-set` values are propagated to `chart-testing`
      check.
- [ ] Skip `chart-testing` tests in the case the file the `KUBECONFIG`
      environment variable is referring to does not exist.
	  
Closes #134.