### PR TITLE
Improve reason output when chart-testing fails

### DIFF
--- a/hack/get-helm.sh
+++ b/hack/get-helm.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-curl -O https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.5.0/helm-linux-amd64.tar.gz
-mkdir -p /usr/local/bin
-tar xfz helm-linux-amd64.tar.gz -C /usr/local/bin
-mv /usr/local/bin/helm-linux-amd64 /usr/local/bin/helm
+HELM_VERSION=${HELM_VERSION-3.5.0}
+DOWNLOAD_DIR=${DOWNLOAD_DIR-/tmp/chart-verifier}
+INSTALL_DIR=${INSTALL_DIR-/usr/local/bin}
+
+mkdir -p "${DOWNLOAD_DIR}"
+pushd "${DOWNLOAD_DIR}"
+curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/helm/${HELM_VERSION}/helm-linux-amd64.tar.gz
+tar xfz helm-linux-amd64.tar.gz
+mkdir -p "${INSTALL_DIR}"
+mv "${DOWNLOAD_DIR}/helm-linux-amd64" "${INSTALL_DIR}/helm"
+popd

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/helm/chart-testing/v3/pkg/chart"
 	"github.com/helm/chart-testing/v3/pkg/config"
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/helm/chart-testing/v3/pkg/util"
 	"github.com/imdario/mergo"
 	"github.com/redhat-certification/chart-verifier/pkg/tool"
@@ -63,7 +62,7 @@ func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
 func ChartTesting(opts *CheckOptions) (Result, error) {
 
 	cfg := buildChartTestingConfiguration(opts)
-	procExec := exec.NewProcessExecutor(cfg.Debug)
+	procExec := tool.NewProcessExecutor(cfg.Debug)
 	extraArgs := strings.Fields(cfg.HelmExtraArgs)
 	helm := tool.NewHelm(procExec, extraArgs)
 	kubectl := tool.NewKubectl(procExec)

--- a/pkg/chartverifier/verifier.go
+++ b/pkg/chartverifier/verifier.go
@@ -18,7 +18,6 @@ package chartverifier
 
 import (
 	"github.com/Masterminds/semver"
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/tool"
 	"github.com/spf13/viper"
@@ -81,7 +80,7 @@ type version struct{}
 
 func (ver *version) getVersion(debug bool) (string, error) {
 
-	procExec := exec.NewProcessExecutor(debug)
+	procExec := tool.NewProcessExecutor(debug)
 	oc := tool.NewOc(procExec)
 
 	// oc.GetVersion() returns an error both in case the oc command can't be executed and

--- a/pkg/tool/exec.go
+++ b/pkg/tool/exec.go
@@ -7,14 +7,14 @@ import (
 	"github.com/helm/chart-testing/v3/pkg/exec"
 )
 
-type ProcessExecutor struct{
-    exec.ProcessExecutor
+type ProcessExecutor struct {
+	exec.ProcessExecutor
 }
 
 func NewProcessExecutor(debug bool) ProcessExecutor {
-    return ProcessExecutor{
-        exec.NewProcessExecutor(debug),
-    }
+	return ProcessExecutor{
+		exec.NewProcessExecutor(debug),
+	}
 }
 
 func (p ProcessExecutor) RunProcessAndCaptureOutput(executable string, execArgs ...interface{}) (string, error) {
@@ -24,9 +24,9 @@ func (p ProcessExecutor) RunProcessAndCaptureOutput(executable string, execArgs 
 // RunProcessInDirAndCaptureOutput overrides exec.ProcessExecutor's and inject the command line and any streamed content
 // to either Stdout or Stderr into the returned error, if any.
 func (p ProcessExecutor) RunProcessInDirAndCaptureOutput(
-    workingDirectory string,
-    executable string,
-    execArgs ...interface{},
+	workingDirectory string,
+	executable string,
+	execArgs ...interface{},
 ) (string, error) {
 	cmd, err := p.CreateProcess(executable, execArgs...)
 	if err != nil {
@@ -43,12 +43,12 @@ func (p ProcessExecutor) RunProcessInDirAndCaptureOutput(
 	if err != nil {
 		if len(capturedOutput) == 0 {
 			return "", fmt.Errorf(
-                "Error running process: executing %s with args %q: %w",
-                executable, execArgsStr, err)
+				"Error running process: executing %s with args %q: %w",
+				executable, execArgsStr, err)
 		}
 		return capturedOutput, fmt.Errorf(
-            "Error running process: executing %s with args %q: %w\n---\n%s",
-            executable, execArgsStr, err, capturedOutput)
+			"Error running process: executing %s with args %q: %w\n---\n%s",
+			executable, execArgsStr, err, capturedOutput)
 	}
 	return capturedOutput, nil
 }

--- a/pkg/tool/exec.go
+++ b/pkg/tool/exec.go
@@ -1,0 +1,54 @@
+package tool
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/helm/chart-testing/v3/pkg/exec"
+)
+
+type ProcessExecutor struct{
+    exec.ProcessExecutor
+}
+
+func NewProcessExecutor(debug bool) ProcessExecutor {
+    return ProcessExecutor{
+        exec.NewProcessExecutor(debug),
+    }
+}
+
+func (p ProcessExecutor) RunProcessAndCaptureOutput(executable string, execArgs ...interface{}) (string, error) {
+	return p.RunProcessInDirAndCaptureOutput("", executable, execArgs...)
+}
+
+// RunProcessInDirAndCaptureOutput overrides exec.ProcessExecutor's and inject the command line and any streamed content
+// to either Stdout or Stderr into the returned error, if any.
+func (p ProcessExecutor) RunProcessInDirAndCaptureOutput(
+    workingDirectory string,
+    executable string,
+    execArgs ...interface{},
+) (string, error) {
+	cmd, err := p.CreateProcess(executable, execArgs...)
+	if err != nil {
+		return "", err
+	}
+
+	cmd.Dir = workingDirectory
+	bytes, err := cmd.CombinedOutput()
+	capturedOutput := strings.TrimSpace(string(bytes))
+
+	execArgsCopy := toStringArray(execArgs)
+	execArgsStr := strings.Join(execArgsCopy, " ")
+
+	if err != nil {
+		if len(capturedOutput) == 0 {
+			return "", fmt.Errorf(
+                "Error running process: executing %s with args %q: %w",
+                executable, execArgsStr, err)
+		}
+		return capturedOutput, fmt.Errorf(
+            "Error running process: executing %s with args %q: %w\n---\n%s",
+            executable, execArgsStr, err, capturedOutput)
+	}
+	return capturedOutput, nil
+}

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -40,8 +40,10 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 		// executing helm with args 'helm install ...': <process error>
 		// ---
 		// <stdout capture>
-		_ = stdoutCapture
-		return fmt.Errorf("executing helm with args %q: %w", strings.Join(helmArgs, " "), err)
+        if stdoutCapture == "" {
+            return fmt.Errorf("executing helm with args %q: %w", strings.Join(helmArgs, " "), err)
+        }
+        return fmt.Errorf("executing helm with args %q: %w\n---\n%s", strings.Join(helmArgs, " "), err, stdoutCapture)
 	}
 
 	return nil

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -23,7 +23,7 @@ func NewHelm(exec ProcessExecutor, extraArgs []string) Helm {
 }
 
 func toStringArray(args []interface{}) []string {
-    copy := make([]string, len(args))
+	copy := make([]string, len(args))
 	for i, a := range args {
 		copy[i] = fmt.Sprint(a)
 	}
@@ -31,7 +31,7 @@ func toStringArray(args []interface{}) []string {
 }
 
 func toInterfaceArray(args []string) []interface{} {
-    copy := make([]interface{}, len(args))
+	copy := make([]interface{}, len(args))
 	for i, a := range args {
 		copy[i] = a
 	}
@@ -48,7 +48,7 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 
 	helmArgs := []interface{}{"install", release, chart, "--namespace", namespace, "--wait"}
 	helmArgs = append(helmArgs, values...)
-	helmArgs = append(helmArgs,  toInterfaceArray(h.extraArgs)...)
+	helmArgs = append(helmArgs, toInterfaceArray(h.extraArgs)...)
 
 	_, err := h.RunProcessAndCaptureOutput("helm", helmArgs...)
 	return err

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -37,11 +37,11 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 	if stdoutCapture, err := h.RunProcessAndCaptureOutput("helm", helmArgs); err != nil {
 		// augments the resulting error with the contents captured from Stdout, in the following format:
 		//
-		// executing helm with args 'helm install ...': <process error> (output follows)
+		// executing helm with args 'helm install ...': <process error>
 		// ---
 		// <stdout capture>
-		return fmt.Errorf("executing helm with args %q: %w (output follows)\n---\n%s",
-			strings.Join(helmArgs, " "), err, stdoutCapture)
+		_ = stdoutCapture
+		return fmt.Errorf("executing helm with args %q: %w", strings.Join(helmArgs, " "), err)
 	}
 
 	return nil

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -23,19 +23,19 @@ func NewHelm(exec ProcessExecutor, extraArgs []string) Helm {
 }
 
 func toStringArray(args []interface{}) []string {
-    argsCopy := make([]string, len(args))
+    copy := make([]string, len(args))
 	for i, a := range args {
-		argsCopy[i] = fmt.Sprint(a)
+		copy[i] = fmt.Sprint(a)
 	}
-	return argsCopy
+	return copy
 }
 
 func toInterfaceArray(args []string) []interface{} {
-    argsCopy := make([]interface{}, len(args))
+    copy := make([]interface{}, len(args))
 	for i, a := range args {
-		argsCopy[i] = a
+		copy[i] = a
 	}
-	return argsCopy
+	return copy
 }
 
 // InstallWithValues overrides chart-testing's tool.Helm method to execute the modified RunProcessAndCaptureOutput

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +32,7 @@ func TestInstallWithValues(t *testing.T) {
 			"Error running process: executing helm with args \"install %s %s --namespace %s --wait\": "+
 				"exec: \"helm\": executable file not found in $PATH",
 			release, chrt, namespace)
-		h := NewHelm(exec.NewProcessExecutor(false), []string{})
+		h := NewHelm(NewProcessExecutor(false), []string{})
 
 		// act
 		// for this test, none of the arguments matter si
@@ -54,7 +53,7 @@ func TestInstallWithValues(t *testing.T) {
 			"Error running process: executing helm with args \"install %s %s --namespace %s --wait\": "+
 				"exit status 1\n---\nError: failed to download \"%s\" (hint: running `helm repo update` may help)",
 			release, chrt, namespace, chrt)
-		processExecutor := exec.NewProcessExecutor(false)
+		processExecutor := NewProcessExecutor(false)
 		extraArgs := []string{}
 		h := NewHelm(processExecutor, extraArgs)
 

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -61,7 +61,7 @@ func TestInstallWithValues(t *testing.T) {
 		// act
 		err := h.InstallWithValues(chrt, valuesFile, namespace, release)
 
-        // assert
+		// assert
 		require.Error(t, err)
 		require.Equal(t, expectedErrorMessage, err.Error())
 	})

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -30,8 +30,8 @@ func TestInstallWithValues(t *testing.T) {
 		release := "non-existing-release"
 		namespace := "default"
 		expectedErrorMessage := fmt.Sprintf(
-			"executing helm with args \"install %s %s --namespace %s --wait\": "+
-				"Error running process: exec: \"helm\": executable file not found in $PATH",
+			"Error running process: executing helm with args \"install %s %s --namespace %s --wait\": "+
+				"exec: \"helm\": executable file not found in $PATH",
 			release, chrt, namespace)
 		h := NewHelm(exec.NewProcessExecutor(false), []string{})
 
@@ -51,8 +51,8 @@ func TestInstallWithValues(t *testing.T) {
 		valuesFile := ""
 		namespace := "default"
 		expectedErrorMessage := fmt.Sprintf(
-			"executing helm with args \"install %s %s --namespace %s --wait\": "+
-				"Error running process: exit status 1\n---\nError: failed to download \"%s\" (hint: running `helm repo update` may help)",
+			"Error running process: executing helm with args \"install %s %s --namespace %s --wait\": "+
+				"exit status 1\n---\nError: failed to download \"%s\" (hint: running `helm repo update` may help)",
 			release, chrt, namespace, chrt)
 		processExecutor := exec.NewProcessExecutor(false)
 		extraArgs := []string{}

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -1,14 +1,50 @@
 package tool
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/stretchr/testify/require"
 )
 
+func temporarilyToggleEnv(name string) (untoggleFn func(), err error) {
+    originalValue := os.Getenv(name)
+    err = os.Unsetenv(name)
+    untoggleFn = func() {
+        os.Setenv(name, originalValue)
+    }
+    return
+}
+
 func TestInstallWithValues(t *testing.T) {
-	t.Run("failure with empty Stdout capture should not include detail block", func(t *testing.T) {
+	t.Run("helm not available in path", func(t *testing.T) {
+        untogglePathEnv, err := temporarilyToggleEnv("PATH")
+        require.NoError(t, err)
+        defer untogglePathEnv()
+
+		// arrange
+		valuesFile := ""
+		chrt := "non-existing-chart.tgz"
+		release := "non-existing-release"
+		namespace := "default"
+		expectedErrorMessage := fmt.Sprintf(
+			"executing helm with args \"install %s %s --namespace %s --wait\": "+
+				"Error running process: exec: \"helm\": executable file not found in $PATH",
+			release, chrt, namespace)
+		h := NewHelm(exec.NewProcessExecutor(false), []string{})
+
+		// act
+		// for this test, none of the arguments matter si
+		err = h.InstallWithValues(chrt, valuesFile, namespace, release)
+
+		// assert
+		require.Error(t, err)
+		require.Equal(t, expectedErrorMessage, err.Error())
+	})
+
+	t.Run("helm failure should include content streamed to both Stderr and Stdout", func(t *testing.T) {
 		// arrange
 		processExecutor := exec.NewProcessExecutor(false)
 		extraArgs := []string{}
@@ -23,11 +59,9 @@ func TestInstallWithValues(t *testing.T) {
 
 		// assert
 		require.Error(t, err)
-
-        // 
-        require.Equal(
-            t, "executing helm with args \"install non-existing-release non-existing-chart.tgz --namespace default --wait\": " +
-                "Error running process: exit status 1",
-            err.Error())
+		require.Equal(
+			t, "executing helm with args \"install non-existing-release non-existing-chart.tgz --namespace default --wait\": "+
+				"Error running process: exit status 1\n--\nError: failed to download \"non-existing-chart.tgz\" (hint: running `helm repo update` may help)",
+			err.Error())
 	})
 }

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -8,19 +8,26 @@ import (
 )
 
 func TestInstallWithValues(t *testing.T) {
-    // arrange
-    processExecutor := exec.NewProcessExecutor(false)
-    extraArgs := []string{}
-	h := NewHelm(processExecutor, extraArgs)
+	t.Run("failure with empty Stdout capture should not include detail block", func(t *testing.T) {
+		// arrange
+		processExecutor := exec.NewProcessExecutor(false)
+		extraArgs := []string{}
+		h := NewHelm(processExecutor, extraArgs)
 
-    // act
-    chrt := ""
-    release := ""
-    valuesFile := ""
-    namespace := "default"
-    err := h.InstallWithValues(chrt, valuesFile, namespace, release)
+		// act
+		chrt := "non-existing-chart.tgz"
+		release := "non-existing-release"
+		valuesFile := ""
+		namespace := "default"
+		err := h.InstallWithValues(chrt, valuesFile, namespace, release)
 
-    // assert
-    require.Error(t, err)
-    
+		// assert
+		require.Error(t, err)
+
+        // 
+        require.Equal(
+            t, "executing helm with args \"install non-existing-release non-existing-chart.tgz --namespace default --wait\": " +
+                "Error running process: exit status 1",
+            err.Error())
+	})
 }

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -1,0 +1,26 @@
+package tool
+
+import (
+	"testing"
+
+	"github.com/helm/chart-testing/v3/pkg/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallWithValues(t *testing.T) {
+    // arrange
+    processExecutor := exec.NewProcessExecutor(false)
+    extraArgs := []string{}
+	h := NewHelm(processExecutor, extraArgs)
+
+    // act
+    chrt := ""
+    release := ""
+    valuesFile := ""
+    namespace := "default"
+    err := h.InstallWithValues(chrt, valuesFile, namespace, release)
+
+    // assert
+    require.Error(t, err)
+    
+}

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/helm/chart-testing/v3/pkg/tool"
 )
 
@@ -12,12 +11,12 @@ import (
 // chart-testing to silence output being streamed to Stdout.
 type Kubectl struct {
 	tool.Kubectl
-	exec.ProcessExecutor
+	ProcessExecutor
 }
 
-func NewKubectl(exec exec.ProcessExecutor) Kubectl {
+func NewKubectl(exec ProcessExecutor) Kubectl {
 	return Kubectl{
-		tool.NewKubectl(exec),
+		tool.NewKubectl(exec.ProcessExecutor),
 		exec,
 	}
 }

--- a/pkg/tool/oc.go
+++ b/pkg/tool/oc.go
@@ -3,24 +3,23 @@ package tool
 import (
 	"fmt"
 
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"gopkg.in/yaml.v3"
 )
 
 type Oc struct {
-	exec exec.ProcessExecutor
+	ProcessExecutor
 }
 
-func NewOc(exec exec.ProcessExecutor) Oc {
+func NewOc(exec ProcessExecutor) Oc {
 	return Oc{
-		exec: exec,
+		ProcessExecutor: exec,
 	}
 }
 
 const osVersionKey = "openshiftVersion"
 
 func (o Oc) GetVersion() (string, error) {
-	rawOutput, err := o.exec.RunProcessAndCaptureOutput("oc", "version", "-o", "yaml")
+	rawOutput, err := o.RunProcessAndCaptureOutput("oc", "version", "-o", "yaml")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This change list improves in the Stderr and Stdout capture of helm and
kubectl/oc when errors are triggered not only by the absence of those
programs, but also when those programs are available but return
errors.

Closes #114