### PR TITLE
Recognize kube version 1.21 as openshift 4.8

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,1 @@
+package cmd

--- a/pkg/tool/oc.go
+++ b/pkg/tool/oc.go
@@ -20,6 +20,7 @@ const osVersionKey = "serverVersion"
 
 // Based on https://access.redhat.com/solutions/4870701
 var kubeOpenShiftVersionMap map[string]string = map[string]string{
+	"1.21": "4.8.0",
 	"1.20": "4.7.0",
 	"1.19": "4.6.0",
 	"1.18": "4.5.0",

--- a/pkg/tool/oc_test.go
+++ b/pkg/tool/oc_test.go
@@ -2,23 +2,43 @@ package tool
 
 import "testing"
 
-type fakeProcessExecutor struct{}
+type fakeProcessExecutor struct {
+	Output string
+}
 
-var output = `
+var output47 = `
 serverVersion:
   major: "1"
   minor: "20"
 `
 
 func (p fakeProcessExecutor) RunProcessAndCaptureOutput(executable string, execArgs ...interface{}) (string, error) {
-	return output, nil
+	return p.Output, nil
 }
 
-func TestOcVersion(t *testing.T) {
-	fp := fakeProcessExecutor{}
+func TestOcVersion47(t *testing.T) {
+	fp := fakeProcessExecutor{Output: output47}
 	oc := NewOc(fp)
 	version, _ := oc.GetVersion()
 	if version != "4.7.0" {
+		t.Error("Version mismatch", version)
+	}
+}
+
+type fakeProcessExecutor48 struct {
+}
+
+var output48 = `
+serverVersion:
+  major: "1"
+  minor: "21"
+`
+
+func TestOcVersion48(t *testing.T) {
+	fp := fakeProcessExecutor{Output: output48}
+	oc := NewOc(fp)
+	version, _ := oc.GetVersion()
+	if version != "4.8.0" {
 		t.Error("Version mismatch", version)
 	}
 }

--- a/pkg/tool/oc_test.go
+++ b/pkg/tool/oc_test.go
@@ -25,9 +25,6 @@ func TestOcVersion47(t *testing.T) {
 	}
 }
 
-type fakeProcessExecutor48 struct {
-}
-
 var output48 = `
 serverVersion:
   major: "1"


### PR DESCRIPTION
Added Kube version 1.21 to be recognized as OpenShift version 4.8

Added test to confirm it works