### PR TITLE
cmd/check: add check command to parse report.yaml

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultProfile   = "default"
+	partnerProfile   = "partner"
+	redhatProfile    = "redhat"
+	communityProfile = "community"
+)
+
+type checkResult struct {
+	Profile     string                       `json:"profile,omitempty" yaml:"profile,omitempty"`
+	Passed      int                          `json:"passed" yaml:"passed"`
+	Failed      int                          `json:"failed" yaml:"failed"`
+	Unknown     int                          `json:"unknown" yaml:"unknown"`
+	Message     []*chartverifier.CheckReport `json:"message" yaml:"message"`
+	OtherResult *checkResult                 `json:"other-result,omitempty" yaml:"other-result,omitempty"`
+}
+
+type checkOptions struct {
+	Profile string
+}
+
+func init() {
+	rootCmd.AddCommand(NewCheckCmd(viper.GetViper()))
+}
+
+func checkReport(path string, profile string) (checkResult, error) {
+	result := checkResult{}
+	reportBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return result, fmt.Errorf("reading report file: %w", err)
+	}
+
+	var report chartverifier.Report
+	err = yaml.Unmarshal(reportBytes, &report)
+	if err != nil {
+		return result, fmt.Errorf("unmarshalling report file contents: %w", err)
+	}
+
+	// TODO: use different profiles based on command line argument
+	var p *profiles.Profile
+	switch profile {
+	case partnerProfile:
+		p = profiles.Get()
+		result.Profile = partnerProfile
+	case redhatProfile:
+		p = profiles.Get()
+		result.Profile = redhatProfile
+	case communityProfile:
+		p = profiles.Get()
+		result.Profile = communityProfile
+	default:
+		p = profiles.Get()
+		result.Profile = defaultProfile
+	}
+
+	profileChecks := p.Checks
+	profileChecksSet := make(map[string]bool)
+	for _, c := range profileChecks {
+		splitter := regexp.MustCompile(`/`)
+		splitCheck := splitter.Split(c.Name, -1)
+		profileChecksSet[splitCheck[1]] = true
+	}
+
+	otherResult := checkResult{}
+
+	for _, cr := range report.Results {
+		if _, ok := profileChecksSet[string(cr.Check)]; ok {
+			switch cr.Outcome {
+			case chartverifier.FailOutcomeType:
+				result.Failed++
+				result.Message = append(result.Message, cr)
+			case chartverifier.PassOutcomeType:
+				result.Passed++
+			case chartverifier.UnknownOutcomeType:
+				result.Unknown++
+				result.Message = append(result.Message, cr)
+			default:
+				return result, fmt.Errorf("checking report results: incorrect outcome type '%v' for '%v'", cr.Outcome, cr.Check)
+			}
+		} else {
+			switch cr.Outcome {
+			case chartverifier.FailOutcomeType:
+				otherResult.Failed++
+				otherResult.Message = append(otherResult.Message, cr)
+			case chartverifier.PassOutcomeType:
+				otherResult.Passed++
+			case chartverifier.UnknownOutcomeType:
+				otherResult.Unknown++
+				otherResult.Message = append(otherResult.Message, cr)
+			default:
+				return result, fmt.Errorf("checking report results: incorrect outcome type '%v' for '%v'", cr.Outcome, cr.Check)
+			}
+		}
+	}
+
+	if otherResult.Passed+otherResult.Failed+otherResult.Unknown > 0 {
+		result.OtherResult = &otherResult
+	}
+
+	return result, nil
+}
+
+// NewCheckCmd creates a command that sanity checks report.
+func NewCheckCmd(config *viper.Viper) *cobra.Command {
+
+	// verifyOpts contains this specific command options.
+	checkOpts := &checkOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "check <report-uri>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Checks the result of a Helm chart report",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := checkReport(args[0], checkOpts.Profile)
+			if err != nil {
+				return err
+			}
+
+			if outputFormatFlag == "json" {
+				b, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+
+				cmd.Println(string(b))
+
+			} else {
+				b, err := yaml.Marshal(result)
+				if err != nil {
+					return err
+				}
+
+				cmd.Println(string(b))
+			}
+			return nil
+		},
+	}
+
+	settings.AddFlags(cmd.Flags())
+
+	cmd.Flags().StringVarP(&outputFormatFlag, "output", "o", "", "the output format: default, json or yaml")
+
+	cmd.Flags().StringVarP(&checkOpts.Profile, "profile", "p", defaultProfile, "check according to specific profile (partner, redhat, community)")
+
+	return cmd
+}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllPassReport(t *testing.T) {
+	t.Run("Default profile with all pass result", func(t *testing.T) {
+		cmd := NewCheckCmd(viper.New())
+		outBuf := bytes.NewBufferString("")
+		cmd.SetOut(outBuf)
+		errBuf := bytes.NewBufferString("")
+		cmd.SetErr(errBuf)
+
+		cmd.SetArgs([]string{
+			"testdata/report-all-pass.yaml",
+		})
+		require.NoError(t, cmd.Execute())
+		require.NotEmpty(t, outBuf.String())
+
+		expected := "profile: default\n" +
+			"passed: 11\n" +
+			"failed: 0\n" +
+			"unknown: 0\n" +
+			"message: []\n"
+		require.Contains(t, outBuf.String(), expected)
+	})
+}
+
+func TestInvalidReport(t *testing.T) {
+	t.Run("Default profile with invalid result", func(t *testing.T) {
+		cmd := NewCheckCmd(viper.New())
+		outBuf := bytes.NewBufferString("")
+		cmd.SetOut(outBuf)
+		errBuf := bytes.NewBufferString("")
+		cmd.SetErr(errBuf)
+
+		cmd.SetArgs([]string{
+			"testdata/report-invalid.yaml",
+		})
+		require.Error(t, cmd.Execute())
+		require.NotEmpty(t, outBuf.String())
+		require.NotEmpty(t, errBuf.String())
+
+		expectedStdOut :=
+			`Usage:
+  check <report-uri> [flags]
+
+Flags:
+      --debug                       enable verbose output
+  -h, --help                        help for check
+      --kube-apiserver string       the address and the port for the Kubernetes API server
+      --kube-as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --kube-as-user string         username to impersonate for the operation
+      --kube-ca-file string         the certificate authority file for the Kubernetes API server connection
+      --kube-context string         name of the kubeconfig context to use
+      --kube-token string           bearer token used for authentication
+      --kubeconfig string           path to the kubeconfig file
+  -n, --namespace string            namespace scope for this request
+  -o, --output string               the output format: default, json or yaml
+  -p, --profile string              check according to specific profile (partner, redhat, community) (default "default")
+      --registry-config string      path to the registry config file (default "/home/abai/.config/helm/registry.json")
+      --repository-cache string     path to the file containing cached repository indexes (default "/home/abai/.cache/helm/repository")
+      --repository-config string    path to the file containing repository names and URLs (default "/home/abai/.config/helm/repositories.yaml")
+`
+		expectedStdErr := `checking report results: incorrect outcome type 'INVALID' for 'chart-testing'`
+		require.Contains(t, outBuf.String(), expectedStdOut)
+		require.Contains(t, errBuf.String(), expectedStdErr)
+	})
+}
+
+func TestReportWithFails(t *testing.T) {
+	t.Run("Default profile with mixed outcome type", func(t *testing.T) {
+		cmd := NewCheckCmd(viper.New())
+		outBuf := bytes.NewBufferString("")
+		cmd.SetOut(outBuf)
+		errBuf := bytes.NewBufferString("")
+		cmd.SetErr(errBuf)
+
+		cmd.SetArgs([]string{
+			"testdata/report-with-fails.yaml",
+		})
+		require.NoError(t, cmd.Execute())
+		require.NotEmpty(t, outBuf.String())
+
+		expected :=
+			`profile: default
+passed: 8
+failed: 2
+unknown: 1
+message:
+  - check: images-are-certified
+    type: Mandatory
+    outcome: FAIL
+    reason: 'Error: some images are not certified.'
+  - check: helm-lint
+    type: Mandatory
+    outcome: UNKNOWN
+    reason: Unknown outcome.
+  - check: chart-testing
+    type: Mandatory
+    outcome: FAIL
+    reason: 'Error: chart testin failed.'
+
+`
+		require.Contains(t, outBuf.String(), expected)
+	})
+}

--- a/cmd/testdata/report-all-pass.yaml
+++ b/cmd/testdata/report-all-pass.yaml
@@ -1,0 +1,49 @@
+apiversion: v1
+kind: verify-report
+metadata:
+results:
+  - check: contains-test
+    type: Mandatory
+    outcome: PASS
+    reason: Chart test files exist
+  - check: contains-values-schema
+    type: Mandatory
+    outcome: PASS
+    reason: Values schema file exist
+  - check: has-kubeversion
+    type: Mandatory
+    outcome: PASS
+    reason: Kubernetes version specified
+  - check: not-contains-crds
+    type: Mandatory
+    outcome: PASS
+    reason: Chart does not contain CRDs
+  - check: images-are-certified
+    type: Mandatory
+    outcome: PASS
+    reason: |-
+        Test log: Images are certified.
+  - check: has-readme
+    type: Mandatory
+    outcome: PASS
+    reason: Chart has a README
+  - check: is-helm-v3
+    type: Mandatory
+    outcome: PASS
+    reason: API version is V2, used in Helm 3
+  - check: contains-values
+    type: Mandatory
+    outcome: PASS
+    reason: Values file exist
+  - check: helm-lint
+    type: Mandatory
+    outcome: PASS
+    reason: Helm lint successful
+  - check: not-contain-csi-objects
+    type: Mandatory
+    outcome: PASS
+    reason: CSI objects do not exist
+  - check: chart-testing
+    type: Mandatory
+    outcome: PASS
+    reason: Chart tests have passed

--- a/cmd/testdata/report-invalid.yaml
+++ b/cmd/testdata/report-invalid.yaml
@@ -1,0 +1,49 @@
+apiversion: v1
+kind: verify-report
+metadata:
+results:
+  - check: contains-test
+    type: Mandatory
+    outcome: PASS
+    reason: Chart test files exist
+  - check: contains-values-schema
+    type: Mandatory
+    outcome: PASS
+    reason: Values schema file exist
+  - check: has-kubeversion
+    type: Mandatory
+    outcome: PASS
+    reason: Kubernetes version specified
+  - check: not-contains-crds
+    type: Mandatory
+    outcome: PASS
+    reason: Chart does not contain CRDs
+  - check: images-are-certified
+    type: Mandatory
+    outcome: PASS
+    reason: |-
+        Test log: Images are certified.
+  - check: has-readme
+    type: Mandatory
+    outcome: PASS
+    reason: Chart has a README
+  - check: is-helm-v3
+    type: Mandatory
+    outcome: PASS
+    reason: API version is V2, used in Helm 3
+  - check: contains-values
+    type: Mandatory
+    outcome: PASS
+    reason: Values file exist
+  - check: helm-lint
+    type: Mandatory
+    outcome: PASS
+    reason: Helm lint successful
+  - check: not-contain-csi-objects
+    type: Mandatory
+    outcome: PASS
+    reason: CSI objects do not exist
+  - check: chart-testing
+    type: Mandatory
+    outcome: INVALID
+    reason: Invalid outcome.

--- a/cmd/testdata/report-with-fails.yaml
+++ b/cmd/testdata/report-with-fails.yaml
@@ -1,0 +1,50 @@
+apiversion: v1
+kind: verify-report
+metadata:
+results:
+  - check: contains-test
+    type: Mandatory
+    outcome: PASS
+    reason: Chart test files exist
+  - check: contains-values-schema
+    type: Mandatory
+    outcome: PASS
+    reason: Values schema file exist
+  - check: has-kubeversion
+    type: Mandatory
+    outcome: PASS
+    reason: Kubernetes version specified
+  - check: not-contains-crds
+    type: Mandatory
+    outcome: PASS
+    reason: Chart does not contain CRDs
+  - check: images-are-certified
+    type: Mandatory
+    outcome: FAIL
+    reason: |-
+        Error: some images are not certified.
+  - check: has-readme
+    type: Mandatory
+    outcome: PASS
+    reason: Chart has a README
+  - check: is-helm-v3
+    type: Mandatory
+    outcome: PASS
+    reason: API version is V2, used in Helm 3
+  - check: contains-values
+    type: Mandatory
+    outcome: PASS
+    reason: Values file exist
+  - check: helm-lint
+    type: Mandatory
+    outcome: UNKNOWN
+    reason: Unknown outcome.
+  - check: not-contain-csi-objects
+    type: Mandatory
+    outcome: PASS
+    reason: CSI objects do not exist
+  - check: chart-testing
+    type: Mandatory
+    outcome: FAIL
+    reason: |-
+        Error: chart testin failed.


### PR DESCRIPTION
As part of work to add profile support in chart-verifier, we need to
move the hardcoded logic from chart submission workflow to chart-verifier.

An example is the
https://github.com/openshift-helm-charts/charts/blob/main/scripts/src/chartprreview/verify-report.sh#L197
where we hardcoded mandatory checks. Here we will change to use profiles
defined within verifier to minimize disparity. The next step would be to move the `getAnnotations` logic to verifier.

Signed-off-by: Allen Bai <abai@redhat.com>