### PR TITLE
Sha values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,6 @@ COPY --from=build /tmp/src/out/chart-verifier /app/chart-verifier
 
 COPY --from=build /usr/local/bin/* /usr/local/bin/
 
+COPY ./config /app/config
+
 ENTRYPOINT ["/app/chart-verifier"]

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -118,6 +118,7 @@ func TestCertify(t *testing.T) {
 
 		expected := "results:\n" +
 			"  - check: is-helm-v3\n" +
+			"    version: v1.0\n" +
 			"    type: Mandatory\n" +
 			"    outcome: PASS\n" +
 			"    reason: API version is V2, used in Helm 3\n"
@@ -191,7 +192,7 @@ func TestBuildChecks(t *testing.T) {
 		all.Add(checks.HasReadmeName, "v1.0", nil)
 		all.Add(checks.ChartTestingName, "v1.0", nil)
 		all.Add(checks.ContainsTestName, "v1.0", nil)
-		selected, err := buildChecks(all, enabled, disabled)
+		selected, err := buildChecks(all, viper.New(), enabled, disabled)
 		require.Error(t, err)
 		require.Nil(t, selected)
 	})
@@ -205,7 +206,7 @@ func TestBuildChecks(t *testing.T) {
 		all.Add(checks.HasReadmeName, "v1.0", nil)
 		all.Add(checks.ChartTestingName, "v1.0", nil)
 		all.Add(checks.ContainsTestName, "v1.0", nil)
-		selected, err := buildChecks(all, enabled, disabled)
+		selected, err := buildChecks(all, viper.New(), enabled, disabled)
 		require.Error(t, err)
 		require.Nil(t, selected)
 	})
@@ -219,7 +220,7 @@ func TestBuildChecks(t *testing.T) {
 		all.Add(checks.HasReadmeName, "v1.0", checks.HasReadme)
 		all.Add(checks.ChartTestingName, "v1.0", checks.ChartTesting)
 		all.Add(checks.ContainsTestName, "v1.0", checks.ContainsTest)
-		selected, err := buildChecks(all, enabled, disabled)
+		selected, err := buildChecks(all, viper.New(), enabled, disabled)
 		require.Error(t, err)
 		require.Nil(t, selected)
 	})
@@ -233,7 +234,7 @@ func TestBuildChecks(t *testing.T) {
 		all.Add(checks.HasReadmeName, "v1.0", nil)
 		all.Add(checks.ChartTestingName, "v1.0", nil)
 		all.Add(checks.ContainsTestName, "v1.0", nil)
-		selected, err := buildChecks(all, enabled, disabled)
+		selected, err := buildChecks(all, viper.New(), enabled, disabled)
 		require.NoError(t, err)
 		for k, _ := range all {
 			_, ok := selected[k.Name]

--- a/config/profile-community-1.1.yaml
+++ b/config/profile-community-1.1.yaml
@@ -1,30 +1,31 @@
 apiversion: v1
 kind: verifier-profile
-name: "profile-1.0.0"
+vendorType: community
+version: 1.1
 annotations:
   - "Digest"
   - "OCPVersion"
   - "LastCertifiedTimestamp"
 checks:
     - name: v1.0/has-readme
-      type: Mandatory
+      type: Optional
     - name: v1.0/is-helm-v3
-      type: Mandatory
+      type: Optional
     - name: v1.0/contains-test
-      type: Mandatory
+      type: Optional
     - name: v1.0/contains-values
-      type: Mandatory
+      type: Optional
     - name: v1.0/contains-values-schema
-      type: Mandatory
+      type: Optional
     - name: v1.0/has-kubeversion
-      type: Mandatory
+      type: Optional
     - name: v1.0/not-contains-crds
-      type: Mandatory
+      type: Optional
     - name: v1.0/helm-lint
       type: Mandatory
     - name: v1.0/not-contain-csi-objects
-      type: Mandatory
+      type: Optional
     - name: v1.0/images-are-certified
-      type: Mandatory
+      type: Optional
     - name: v1.0/chart-testing
-      type: Mandatory
+      type: Optional

--- a/config/profile-partner-1.1.yaml
+++ b/config/profile-partner-1.1.yaml
@@ -1,0 +1,31 @@
+apiversion: v1
+kind: verifier-profile
+vendorType: partner
+version: 1.1
+annotations:
+  - "Digest"
+  - "OCPVersion"
+  - "LastCertifiedTimestamp"
+checks:
+    - name: v1.0/has-readme
+      type: Mandatory
+    - name: v1.0/is-helm-v3
+      type: Mandatory
+    - name: v1.0/contains-test
+      type: Mandatory
+    - name: v1.0/contains-values
+      type: Mandatory
+    - name: v1.0/contains-values-schema
+      type: Mandatory
+    - name: v1.0/has-kubeversion
+      type: Mandatory
+    - name: v1.0/not-contains-crds
+      type: Mandatory
+    - name: v1.0/helm-lint
+      type: Mandatory
+    - name: v1.0/not-contain-csi-objects
+      type: Mandatory
+    - name: v1.0/images-are-certified
+      type: Mandatory
+    - name: v1.0/chart-testing
+      type: Mandatory

--- a/config/profile-redhat-1.1.yaml
+++ b/config/profile-redhat-1.1.yaml
@@ -1,0 +1,31 @@
+apiversion: v1
+kind: verifier-profile
+vendorType: redhat
+version: 1.1
+annotations:
+  - "Digest"
+  - "OCPVersion"
+  - "LastCertifiedTimestamp"
+checks:
+    - name: v1.0/has-readme
+      type: Mandatory
+    - name: v1.0/is-helm-v3
+      type: Mandatory
+    - name: v1.0/contains-test
+      type: Mandatory
+    - name: v1.0/contains-values
+      type: Mandatory
+    - name: v1.0/contains-values-schema
+      type: Mandatory
+    - name: v1.0/has-kubeversion
+      type: Mandatory
+    - name: v1.0/not-contains-crds
+      type: Mandatory
+    - name: v1.0/helm-lint
+      type: Mandatory
+    - name: v1.0/not-contain-csi-objects
+      type: Mandatory
+    - name: v1.0/images-are-certified
+      type: Mandatory
+    - name: v1.0/chart-testing
+      type: Mandatory

--- a/pkg/chartverifier/checks/registry.go
+++ b/pkg/chartverifier/checks/registry.go
@@ -58,7 +58,6 @@ type AnnotationHolder interface {
 
 type CheckName string
 type CheckType string
-type Version string
 
 const (
 	HasReadmeName            CheckName = "has-readme"
@@ -82,7 +81,7 @@ const (
 
 type CheckId struct {
 	Name    CheckName
-	Version Version
+	Version string
 }
 type Check struct {
 	CheckId CheckId
@@ -109,7 +108,7 @@ type CheckFunc func(options *CheckOptions) (Result, error)
 
 type Registry interface {
 	Get(id CheckId) (Check, bool)
-	Add(name CheckName, version Version, checkFunc CheckFunc) Registry
+	Add(name CheckName, version string, checkFunc CheckFunc) Registry
 	AllChecks() DefaultRegistry
 }
 
@@ -128,7 +127,7 @@ func (r *DefaultRegistry) Get(id CheckId) (Check, bool) {
 	return v, ok
 }
 
-func (r *DefaultRegistry) Add(name CheckName, version Version, checkFunc CheckFunc) Registry {
+func (r *DefaultRegistry) Add(name CheckName, version string, checkFunc CheckFunc) Registry {
 
 	check := Check{CheckId: CheckId{Name: name, Version: version}, Func: checkFunc}
 	(*r)[check.CheckId] = check

--- a/pkg/chartverifier/helmverifier.go
+++ b/pkg/chartverifier/helmverifier.go
@@ -27,13 +27,14 @@ type VerifierBuilder interface {
 	SetValues(vals map[string]interface{}) VerifierBuilder
 	SetChecks(checks FilteredRegistry) VerifierBuilder
 	SetConfig(config *viper.Viper) VerifierBuilder
+	GetConfig() *viper.Viper
 	SetOverrides([]string) VerifierBuilder
 	SetToolVersion(string) VerifierBuilder
 	SetOpenShiftVersion(string) VerifierBuilder
 	SetSettings(settings *cli.EnvSettings) VerifierBuilder
-	Build() (Vertifier, error)
+	Build() (Verifier, error)
 }
 
-type Vertifier interface {
+type Verifier interface {
 	Verify(uri string) (*Report, error)
 }

--- a/pkg/chartverifier/profiles/default.go
+++ b/pkg/chartverifier/profiles/default.go
@@ -5,28 +5,33 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 )
 
+const (
+	CheckVersion10 = "v1.0"
+)
+
 func getDefaultProfile(msg string) *Profile {
 	profile := Profile{}
 
 	profile.Apiversion = "v1"
 	profile.Kind = "verifier-profile"
 
-	profile.Name = fmt.Sprintf("default-profile : %s", msg)
+	profile.Vendor = PartnerVendorType
+	profile.Version = "1.1"
 
 	profile.Annotations = []Annotation{DigestAnnotation, OCPVersionAnnotation, LastCertifiedTimestampAnnotation}
 
 	profile.Checks = []*Check{
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.HasReadmeName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.IsHelmV3Name), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ContainsTestName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ContainsValuesName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ContainsValuesSchemaName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.HasKubeversionName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.NotContainsCRDsName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.HelmLintName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.NotContainCsiObjectsName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ImagesAreCertifiedName), Type: checks.MandatoryCheckType},
-		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ChartTestingName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.HasReadmeName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.IsHelmV3Name), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.ContainsTestName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.ContainsValuesName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.ContainsValuesSchemaName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.HasKubeversionName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.NotContainsCRDsName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.HelmLintName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.NotContainCsiObjectsName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.ImagesAreCertifiedName), Type: checks.MandatoryCheckType},
+		{Name: fmt.Sprintf("%s/%s", CheckVersion10, checks.ChartTestingName), Type: checks.MandatoryCheckType},
 	}
 
 	profile.Name = fmt.Sprintf("default-profile : %s", msg)

--- a/pkg/chartverifier/profiles/profile.go
+++ b/pkg/chartverifier/profiles/profile.go
@@ -2,27 +2,45 @@ package profiles
 
 import (
 	"errors"
+	"fmt"
+	"github.com/Masterminds/semver"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
+	"io"
+
+	//"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 )
 
 type Annotation string
+type VendorType string
 
 const (
 	DigestAnnotation                 Annotation = "Digest"
 	OCPVersionAnnotation             Annotation = "OCPVersion"
 	LastCertifiedTimestampAnnotation Annotation = "LastCertifiedTimestamp"
+
+	PartnerVendorType   VendorType = "partner"
+	CommunityVendorType VendorType = "community"
+	RedhatVendorType    VendorType = "redhat"
+	DefaultVendorType              = PartnerVendorType
+
+	VendorTypeConfigName string = "verifier.vendortype"
+	VersionConfigName    string = "verifier.version"
 )
 
 type Profile struct {
 	Apiversion  string       `json:"apiversion" yaml:"apiversion"`
 	Kind        string       `json:"kind" yaml:"kind"`
 	Name        string       `json:"name" yaml:"name"`
+	Vendor      VendorType   `json:"vendorType" yaml:"vendorType"`
+	Version     string       `json:"version" yaml:"version"`
 	Annotations []Annotation `json:"annotations" yaml:"annotations"`
 	Checks      []*Check     `json:"checks" yaml:"checks"`
 }
@@ -37,48 +55,90 @@ type FilteredRegistry map[checks.CheckName]checks.Check
 var profile *Profile
 
 func Get() *Profile {
-
-	if profile != nil {
-		return profile
-	}
-
-	fileName, err := getProfileFileName()
-	if err != nil {
-		profile = getDefaultProfile(err.Error())
-		return profile
-	}
-
-	// Open the json file which defines the tests to run
-	profileYaml, err := os.Open(fileName)
-	if err != nil {
-		profile = getDefaultProfile(err.Error())
-		return profile
-	}
-
-	profileBytes, err := ioutil.ReadAll(profileYaml)
-	if err != nil {
-		profile = getDefaultProfile(err.Error())
-		return profile
-	}
-
-	profile = &Profile{}
-	err = yaml.Unmarshal(profileBytes, profile)
-	if err != nil {
-		profile = getDefaultProfile(err.Error())
-		return profile
+	if profile == nil {
+		return getDefaultProfile("No profile set for get")
 	}
 	return profile
 }
 
-func getProfileFileName() (string, error) {
+func New(version string, config *viper.Viper) *Profile {
 
-	_, fn, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", errors.New("failed to get profile directory")
+	profileVersion, _ := semver.NewVersion(version)
+	profileVendorType := DefaultVendorType
+
+	if config != nil {
+		configVersion := config.GetString(VersionConfigName)
+		if len(configVersion) > 0 {
+			requestedVersion, err := semver.NewVersion(configVersion)
+			if err != nil {
+				if !requestedVersion.GreaterThan(profileVersion) {
+					profileVersion = requestedVersion
+				}
+			}
+		}
+		configVendorType := config.GetString(VendorTypeConfigName)
+		if len(configVendorType) > 0 {
+			switch VendorType(configVendorType) {
+			case PartnerVendorType:
+				profileVendorType = PartnerVendorType
+			case CommunityVendorType:
+				profileVendorType = CommunityVendorType
+			case RedhatVendorType:
+				profileVendorType = RedhatVendorType
+			}
+		}
 	}
 
-	// To be update when multiple profiles are supported
-	return filepath.Join(filepath.Dir(fn), "profile-1.0.0.yaml"), nil
+	profile, err := getProfile(profileVendorType, profileVersion)
+
+	if err != nil {
+		profile = getDefaultProfile(err.Error())
+	} else if profile == nil {
+		profile = getDefaultProfile(fmt.Sprintf("No matching profile found : %s : %s :", profileVendorType, profileVersion))
+	}
+
+	return profile
+}
+
+func getProfile(vendor VendorType, version *semver.Version) (*Profile, error) {
+
+	var configDir string
+	if isRunningInDockerContainer() {
+		configDir = filepath.Join("app", "config")
+	} else {
+		_, fn, _, ok := runtime.Caller(0)
+		if !ok {
+			return nil, errors.New("failed to get profile directory")
+		}
+		fileParts := strings.SplitAfter(fn, "chart-verifier")
+		if len(fileParts) > 1 {
+			// running as cli
+			configDir = filepath.Join(fileParts[0], "config")
+		}
+	}
+
+	var profile *Profile
+
+	filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(info.Name(), ".yaml") {
+			profileRead, err := readProfile(path)
+			if err == nil {
+				if strings.Compare(string(profileRead.Vendor), string(vendor)) == 0 {
+					profileVersion, err := semver.NewVersion(string(profileRead.Version))
+					if err == nil {
+						if profileVersion.Major() == version.Major() && profileVersion.Minor() == version.Minor() {
+							profile = profileRead
+							profile.Name = strings.Split(info.Name(), ".yaml")[0]
+							return io.EOF
+						}
+					}
+				}
+			}
+		}
+		return nil
+	})
+
+	return profile, nil
 }
 
 func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRegistry {
@@ -88,7 +148,7 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 	for _, check := range profile.Checks {
 		splitter := regexp.MustCompile(`/`)
 		splitCheck := splitter.Split(check.Name, -1)
-		checkIndex := checks.CheckId{Name: checks.CheckName(splitCheck[1]), Version: checks.Version(splitCheck[0])}
+		checkIndex := checks.CheckId{Name: checks.CheckName(splitCheck[1]), Version: splitCheck[0]}
 		if newCheck, ok := registry[checkIndex]; ok {
 			newCheck.Type = check.Type
 			filteredChecks[checkIndex.Name] = newCheck
@@ -97,4 +157,38 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 
 	return filteredChecks
 
+}
+
+func readProfile(fileName string) (*Profile, error) {
+
+	// Open the json file which defines the tests to run
+	profileYaml, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	profileBytes, err := ioutil.ReadAll(profileYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	profile = &Profile{}
+	err = yaml.Unmarshal(profileBytes, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
+
+}
+
+func isRunningInDockerContainer() bool {
+	// docker creates a .dockerenv file at the root
+	// of the directory tree inside the container.
+	// if this file exists then verifier is running
+	// from inside a container
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	return false
 }

--- a/pkg/chartverifier/profiles/profile.go
+++ b/pkg/chartverifier/profiles/profile.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 	"io"
-
 	//"io"
 	"io/ioutil"
 	"os"
@@ -110,26 +109,26 @@ func getProfile(vendor VendorType, version *semver.Version) (*Profile, error) {
 		if !ok {
 			return nil, errors.New("failed to get profile directory")
 		}
-		fileParts := strings.SplitAfter(fn, "chart-verifier")
-		if len(fileParts) > 1 {
-			// running as cli
-			configDir = filepath.Join(fileParts[0], "config")
-		}
+		index := strings.LastIndex(fn, "chart-verifier/")
+		configDir = fn[0 : index+len("chart-verifier")]
+		configDir = filepath.Join(configDir, "config")
 	}
 
 	var profile *Profile
 
 	filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(info.Name(), ".yaml") {
-			profileRead, err := readProfile(path)
-			if err == nil {
-				if strings.Compare(string(profileRead.Vendor), string(vendor)) == 0 {
-					profileVersion, err := semver.NewVersion(string(profileRead.Version))
-					if err == nil {
-						if profileVersion.Major() == version.Major() && profileVersion.Minor() == version.Minor() {
-							profile = profileRead
-							profile.Name = strings.Split(info.Name(), ".yaml")[0]
-							return io.EOF
+		if info != nil {
+			if strings.HasSuffix(info.Name(), ".yaml") {
+				profileRead, err := readProfile(path)
+				if err == nil {
+					if strings.Compare(string(profileRead.Vendor), string(vendor)) == 0 {
+						profileVersion, err := semver.NewVersion(string(profileRead.Version))
+						if err == nil {
+							if profileVersion.Major() == version.Major() && profileVersion.Minor() == version.Minor() {
+								profile = profileRead
+								profile.Name = strings.Split(info.Name(), ".yaml")[0]
+								return io.EOF
+							}
 						}
 					}
 				}

--- a/pkg/chartverifier/profiles/profile_test.go
+++ b/pkg/chartverifier/profiles/profile_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"reflect"
@@ -11,73 +12,123 @@ import (
 	"testing"
 )
 
+const (
+	NoVersion       string     = ""
+	configVersion10 string     = "1.0"
+	configVersion11 string     = "1.1"
+	configVersion12 string     = "1.2"
+	checkVersion10  string     = CheckVersion10
+	checkVersion11  string     = "v1.1"
+	NoVendorType    VendorType = ""
+)
+
 func TestProfile(t *testing.T) {
 
 	testProfile := getDefaultProfile("test")
-	testProfile.Name = "profile-1.0.0"
+	testProfile.Name = "profile-partner-1.1"
+	config := viper.New()
 
 	t.Run("Profile read from disk should match test profile", func(t *testing.T) {
-		diskProfile := Get()
+		diskProfile := New("1.1.0", config)
 		assert.True(t, cmp.Equal(diskProfile, testProfile), "profiles do not match")
 
 	})
 
 }
 
+func TestGetProfiles(t *testing.T) {
+
+	getAndCheckProfile(t, PartnerVendorType, PartnerVendorType, configVersion11, configVersion11)
+	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, configVersion11, configVersion11)
+	getAndCheckProfile(t, CommunityVendorType, CommunityVendorType, configVersion11, configVersion11)
+	getAndCheckProfile(t, NoVendorType, PartnerVendorType, configVersion11, configVersion11)
+	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, NoVersion, configVersion11)
+	getAndCheckProfile(t, NoVendorType, PartnerVendorType, NoVersion, configVersion11)
+	getAndCheckProfile(t, PartnerVendorType, PartnerVendorType, configVersion12, configVersion11)
+	getAndCheckProfile(t, PartnerVendorType, PartnerVendorType, configVersion10, configVersion11)
+	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, configVersion12, configVersion11)
+	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, configVersion10, configVersion11)
+	getAndCheckProfile(t, CommunityVendorType, CommunityVendorType, configVersion10, configVersion11)
+	getAndCheckProfile(t, CommunityVendorType, CommunityVendorType, configVersion12, configVersion11)
+}
+
+func getAndCheckProfile(t *testing.T, configVendorType, expectVendorType VendorType, configVersion, expectVersion string) {
+
+	config := viper.New()
+	if len(configVendorType) > 0 {
+		config.Set(VendorTypeConfigName, string(configVendorType))
+	}
+	if len(configVersion) > 0 {
+		config.Set(VersionConfigName, configVersion)
+	}
+
+	t.Run(fmt.Sprintf("Request : VendorType config %s expect %s : Version config %s expect %s ", configVendorType, expectVendorType, configVersion, expectVersion), func(t *testing.T) {
+		if len(configVendorType) > 0 {
+			config.Set(VendorTypeConfigName, string(configVendorType))
+		}
+		if len(configVersion) > 0 {
+			config.Set(VersionConfigName, configVersion)
+		}
+		profile := New("1.1.0", config)
+		assert.Equal(t, expectVendorType, profile.Vendor, "VendorType did not match")
+		assert.Equal(t, expectVersion, profile.Version, "Version did not match")
+	})
+}
 func TestProfileFilter(t *testing.T) {
 
 	defaultRegistry := checks.NewRegistry()
 
-	defaultRegistry.Add(checks.HasReadmeName, "v1.0", checks.HasReadme)
-	defaultRegistry.Add(checks.IsHelmV3Name, "v1.0", checks.IsHelmV3)
-	defaultRegistry.Add(checks.ContainsTestName, "v1.0", checks.ContainsTest)
-	defaultRegistry.Add(checks.ContainsValuesName, "v1.0", checks.ContainsValues)
+	defaultRegistry.Add(checks.HasReadmeName, checkVersion10, checks.HasReadme)
+	defaultRegistry.Add(checks.IsHelmV3Name, checkVersion10, checks.IsHelmV3)
+	defaultRegistry.Add(checks.ContainsTestName, checkVersion10, checks.ContainsTest)
+	defaultRegistry.Add(checks.ContainsValuesName, checkVersion10, checks.ContainsValues)
 
-	defaultRegistry.Add(checks.HasReadmeName, "v1.1", checks.HasReadme)
-	defaultRegistry.Add(checks.IsHelmV3Name, "v1.1", checks.IsHelmV3)
-	defaultRegistry.Add(checks.ContainsTestName, "v1.1", checks.ContainsTest)
-	defaultRegistry.Add(checks.ContainsValuesName, "v1.1", checks.ContainsValues)
-	defaultRegistry.Add(checks.ContainsValuesSchemaName, "v1.1", checks.ContainsValuesSchema)
-	defaultRegistry.Add(checks.HasKubeversionName, "v1.1", checks.HasKubeVersion)
-	defaultRegistry.Add(checks.NotContainsCRDsName, "v1.1", checks.NotContainCRDs)
-	defaultRegistry.Add(checks.HelmLintName, "v1.1", checks.HelmLint)
-	defaultRegistry.Add(checks.NotContainsCRDsName, "v1.1", checks.NotContainCSIObjects)
-	defaultRegistry.Add(checks.ImagesAreCertifiedName, "v1.1", checks.ImagesAreCertified)
-	defaultRegistry.Add(checks.ChartTestingName, "v1.1", checks.ChartTesting)
+	defaultRegistry.Add(checks.HasReadmeName, checkVersion11, checks.HasReadme)
+	defaultRegistry.Add(checks.IsHelmV3Name, checkVersion11, checks.IsHelmV3)
+	defaultRegistry.Add(checks.ContainsTestName, checkVersion11, checks.ContainsTest)
+	defaultRegistry.Add(checks.ContainsValuesName, checkVersion11, checks.ContainsValues)
+	defaultRegistry.Add(checks.ContainsValuesSchemaName, checkVersion11, checks.ContainsValuesSchema)
+	defaultRegistry.Add(checks.HasKubeversionName, checkVersion11, checks.HasKubeVersion)
+	defaultRegistry.Add(checks.NotContainsCRDsName, checkVersion11, checks.NotContainCRDs)
+	defaultRegistry.Add(checks.HelmLintName, checkVersion11, checks.HelmLint)
+	defaultRegistry.Add(checks.NotContainsCRDsName, checkVersion11, checks.NotContainCSIObjects)
+	defaultRegistry.Add(checks.ImagesAreCertifiedName, checkVersion11, checks.ImagesAreCertified)
+	defaultRegistry.Add(checks.ChartTestingName, checkVersion11, checks.ChartTesting)
 
-	defaultRegistry.Add("BadHasReadme", "v1.0", checks.HasReadme)
-	defaultRegistry.Add("BadIsHelmV3Name", "v1.0", checks.IsHelmV3)
+	defaultRegistry.Add("BadHasReadme", checkVersion10, checks.HasReadme)
+	defaultRegistry.Add("BadIsHelmV3Name", checkVersion10, checks.IsHelmV3)
 	defaultRegistry.Add("BadContainsTestName", "v1.o", checks.ContainsTest)
 
 	expectedChecks := FilteredRegistry{}
-	expectedChecks[checks.HasReadmeName] = checks.Check{CheckId: checks.CheckId{Name: checks.HasReadmeName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.HasReadme}
-	expectedChecks[checks.IsHelmV3Name] = checks.Check{CheckId: checks.CheckId{Name: checks.IsHelmV3Name, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.IsHelmV3}
-	expectedChecks[checks.ContainsTestName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsTestName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.ContainsTest}
-	expectedChecks[checks.ContainsValuesName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsValuesName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.ContainsValues}
+	expectedChecks[checks.HasReadmeName] = checks.Check{CheckId: checks.CheckId{Name: checks.HasReadmeName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.HasReadme}
+	expectedChecks[checks.IsHelmV3Name] = checks.Check{CheckId: checks.CheckId{Name: checks.IsHelmV3Name, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.IsHelmV3}
+	expectedChecks[checks.ContainsTestName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsTestName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.ContainsTest}
+	expectedChecks[checks.ContainsValuesName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsValuesName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.ContainsValues}
 
+	config := viper.New()
 	t.Run("Checks filtered using profile subset", func(t *testing.T) {
-		filteredChecks := Get().FilterChecks(defaultRegistry.AllChecks())
+		filteredChecks := New("1.1.0", config).FilterChecks(defaultRegistry.AllChecks())
 		CompareCheckMaps(t, expectedChecks, filteredChecks)
 	})
 
-	defaultRegistry.Add(checks.ContainsValuesSchemaName, "v1.0", checks.ContainsValuesSchema)
-	defaultRegistry.Add(checks.HasKubeversionName, "v1.0", checks.HasKubeVersion)
-	defaultRegistry.Add(checks.NotContainsCRDsName, "v1.0", checks.NotContainCRDs)
-	defaultRegistry.Add(checks.HelmLintName, "v1.0", checks.HelmLint)
-	defaultRegistry.Add(checks.NotContainCsiObjectsName, "v1.0", checks.NotContainCSIObjects)
-	defaultRegistry.Add(checks.ImagesAreCertifiedName, "v1.0", checks.ImagesAreCertified)
-	defaultRegistry.Add(checks.ChartTestingName, "v1.0", checks.ChartTesting)
+	defaultRegistry.Add(checks.ContainsValuesSchemaName, checkVersion10, checks.ContainsValuesSchema)
+	defaultRegistry.Add(checks.HasKubeversionName, checkVersion10, checks.HasKubeVersion)
+	defaultRegistry.Add(checks.NotContainsCRDsName, checkVersion10, checks.NotContainCRDs)
+	defaultRegistry.Add(checks.HelmLintName, checkVersion10, checks.HelmLint)
+	defaultRegistry.Add(checks.NotContainCsiObjectsName, checkVersion10, checks.NotContainCSIObjects)
+	defaultRegistry.Add(checks.ImagesAreCertifiedName, checkVersion10, checks.ImagesAreCertified)
+	defaultRegistry.Add(checks.ChartTestingName, checkVersion10, checks.ChartTesting)
 
-	expectedChecks[checks.ContainsValuesSchemaName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsValuesSchemaName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.ContainsValuesSchema}
-	expectedChecks[checks.HasKubeversionName] = checks.Check{CheckId: checks.CheckId{Name: checks.HasKubeversionName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.HasKubeVersion}
-	expectedChecks[checks.NotContainsCRDsName] = checks.Check{CheckId: checks.CheckId{Name: checks.NotContainsCRDsName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.NotContainCRDs}
-	expectedChecks[checks.HelmLintName] = checks.Check{CheckId: checks.CheckId{Name: checks.HelmLintName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.HelmLint}
-	expectedChecks[checks.NotContainCsiObjectsName] = checks.Check{CheckId: checks.CheckId{Name: checks.NotContainCsiObjectsName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.NotContainCSIObjects}
-	expectedChecks[checks.ImagesAreCertifiedName] = checks.Check{CheckId: checks.CheckId{Name: checks.ImagesAreCertifiedName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.ImagesAreCertified}
-	expectedChecks[checks.ChartTestingName] = checks.Check{CheckId: checks.CheckId{Name: checks.ChartTestingName, Version: "v1.0"}, Type: checks.MandatoryCheckType, Func: checks.ChartTesting}
+	expectedChecks[checks.ContainsValuesSchemaName] = checks.Check{CheckId: checks.CheckId{Name: checks.ContainsValuesSchemaName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.ContainsValuesSchema}
+	expectedChecks[checks.HasKubeversionName] = checks.Check{CheckId: checks.CheckId{Name: checks.HasKubeversionName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.HasKubeVersion}
+	expectedChecks[checks.NotContainsCRDsName] = checks.Check{CheckId: checks.CheckId{Name: checks.NotContainsCRDsName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.NotContainCRDs}
+	expectedChecks[checks.HelmLintName] = checks.Check{CheckId: checks.CheckId{Name: checks.HelmLintName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.HelmLint}
+	expectedChecks[checks.NotContainCsiObjectsName] = checks.Check{CheckId: checks.CheckId{Name: checks.NotContainCsiObjectsName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.NotContainCSIObjects}
+	expectedChecks[checks.ImagesAreCertifiedName] = checks.Check{CheckId: checks.CheckId{Name: checks.ImagesAreCertifiedName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.ImagesAreCertified}
+	expectedChecks[checks.ChartTestingName] = checks.Check{CheckId: checks.CheckId{Name: checks.ChartTestingName, Version: checkVersion10}, Type: checks.MandatoryCheckType, Func: checks.ChartTesting}
 
 	t.Run("Checks filtered using profile - full set", func(t *testing.T) {
-		filteredChecks := Get().FilterChecks(defaultRegistry.AllChecks())
+		filteredChecks := New("1.1.0", config).FilterChecks(defaultRegistry.AllChecks())
 		CompareCheckMaps(t, expectedChecks, filteredChecks)
 	})
 

--- a/pkg/chartverifier/report.go
+++ b/pkg/chartverifier/report.go
@@ -46,16 +46,22 @@ type ReportMetadata struct {
 }
 
 type ToolMetadata struct {
-	Version                    string `json:"verifier-version" yaml:"verifier-version"`
-	Profile                    string `json:"profileName" yaml:"profileName"`
-	ChartUri                   string `json:"chart-uri" yaml:"chart-uri"`
-	Digest                     string `json:"digest,omitempty" yaml:"digest,omitempty"`
-	LastCertifiedTimestamp     string `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
-	CertifiedOpenShiftVersions string `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`
+	Version                    string  `json:"verifierVersion" yaml:"verifier-version"`
+	Profile                    Profile `json:"profile" yaml:"profile"`
+	ChartUri                   string  `json:"chart-uri" yaml:"chart-uri"`
+	Digest                     string  `json:"digest,omitempty" yaml:"digest,omitempty"`
+	LastCertifiedTimestamp     string  `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
+	CertifiedOpenShiftVersions string  `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`
+}
+
+type Profile struct {
+	VendorType string `json:"vendorType" yaml:"VendorType"`
+	Version    string `json:"version" yaml:"version"`
 }
 
 type CheckReport struct {
 	Check   checks.CheckName `json:"check" yaml:"check"`
+	Version string           `json:"version" yaml:"version"`
 	Type    checks.CheckType `json:"type" yaml:"type"`
 	Outcome OutcomeType      `json:"outcome" yaml:"outcome"`
 	Reason  string           `json:"reason" yaml:"reason"`
@@ -70,10 +76,11 @@ func newReport() Report {
 	return report
 }
 
-func (c *Report) AddCheck(checkName checks.CheckName, checkType checks.CheckType) *CheckReport {
+func (c *Report) AddCheck(check checks.Check) *CheckReport {
 	newCheck := CheckReport{}
-	newCheck.Check = checkName
-	newCheck.Type = checkType
+	newCheck.Check = check.CheckId.Name
+	newCheck.Type = check.Type
+	newCheck.Version = check.CheckId.Version
 	newCheck.Outcome = UnknownOutcomeType
 	c.Results = append(c.Results, &newCheck)
 	return &newCheck

--- a/pkg/chartverifier/report.go
+++ b/pkg/chartverifier/report.go
@@ -49,7 +49,8 @@ type ToolMetadata struct {
 	Version                    string  `json:"verifierVersion" yaml:"verifier-version"`
 	Profile                    Profile `json:"profile" yaml:"profile"`
 	ChartUri                   string  `json:"chart-uri" yaml:"chart-uri"`
-	Digest                     string  `json:"digest,omitempty" yaml:"digest,omitempty"`
+	Digest                     string  `json:"digest" yaml:"digest"`
+	Digests                    Digest  `json:"digests" yaml:"digests"`
 	LastCertifiedTimestamp     string  `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
 	CertifiedOpenShiftVersions string  `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`
 }
@@ -57,6 +58,11 @@ type ToolMetadata struct {
 type Profile struct {
 	VendorType string `json:"vendorType" yaml:"VendorType"`
 	Version    string `json:"version" yaml:"version"`
+}
+
+type Digest struct {
+	Chart   string `json:"chart" yaml:"chart"`
+	Package string `json:"package,omitempty" yaml:"package,omitempty"`
 }
 
 type CheckReport struct {

--- a/pkg/chartverifier/reportBuilder.go
+++ b/pkg/chartverifier/reportBuilder.go
@@ -17,10 +17,18 @@
 package chartverifier
 
 import (
+	"crypto"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
@@ -92,7 +100,8 @@ func (r *reportBuilder) Build() (*Report, error) {
 	for _, annotation := range profiles.Get().Annotations {
 		switch annotation {
 		case profiles.DigestAnnotation:
-			r.Report.Metadata.ToolMetadata.Digest = GenerateSha(r.Chart.Raw)
+			r.Report.Metadata.ToolMetadata.Digests.Chart = GenerateSha(r.Chart.Raw)
+			r.Report.Metadata.ToolMetadata.Digest = r.Report.Metadata.ToolMetadata.Digests.Chart
 		case profiles.LastCertifiedTimestampAnnotation:
 			r.Report.Metadata.ToolMetadata.LastCertifiedTimestamp = time.Now().Format("2006-01-02T15:04:05.999999-07:00")
 		case profiles.OCPVersionAnnotation:
@@ -103,6 +112,9 @@ func (r *reportBuilder) Build() (*Report, error) {
 			}
 		}
 	}
+
+	r.Report.Metadata.ToolMetadata.Digests.Package = GetPackageDigest(r.Report.Metadata.ToolMetadata.ChartUri)
+
 	return &r.Report, nil
 }
 
@@ -150,4 +162,44 @@ func GenerateSha(rawFiles []*helmchart.File) string {
 	}
 
 	return fmt.Sprintf("sha256:%x", chartSha.Sum(nil))
+}
+
+func GetPackageDigest(uri string) string {
+
+	url, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	var chartReader io.Reader
+	switch url.Scheme {
+	case "http", "https":
+		var chartGetResponse *http.Response
+		chartGetResponse, err = http.Get(url.String())
+		if err == nil {
+			chartReader = chartGetResponse.Body
+		}
+	case "file", "":
+		if strings.HasSuffix(url.Path, ".tgz") {
+			chartReader, _ = os.Open(url.Path)
+		}
+	default:
+		err = errors.Errorf("scheme %q not supported", url.Scheme)
+	}
+	if err != nil || chartReader == nil {
+		return ""
+	}
+	return getDigest(chartReader)
+}
+
+// Digest hashes a reader and returns a SHA256 digest.
+func getDigest(in io.Reader) string {
+	if in == nil {
+		return ""
+	}
+
+	hash := crypto.SHA256.New()
+	if _, err := io.Copy(hash, in); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/pkg/chartverifier/reportBuilder.go
+++ b/pkg/chartverifier/reportBuilder.go
@@ -29,9 +29,9 @@ import (
 
 type ReportBuilder interface {
 	SetToolVersion(name string) ReportBuilder
-	SetProfile(name string) ReportBuilder
+	SetProfile(vendorType profiles.VendorType, version string) ReportBuilder
 	SetChartUri(name string) ReportBuilder
-	AddCheck(name checks.CheckName, checkType checks.CheckType, result checks.Result) ReportBuilder
+	AddCheck(check checks.Check, result checks.Result) ReportBuilder
 	SetChart(chart *helmchart.Chart) ReportBuilder
 	SetCertifiedOpenShiftVersion(version string) ReportBuilder
 	Build() (*Report, error)
@@ -64,8 +64,9 @@ func (r *reportBuilder) SetToolVersion(version string) ReportBuilder {
 	return r
 }
 
-func (r *reportBuilder) SetProfile(profileName string) ReportBuilder {
-	r.Report.Metadata.ToolMetadata.Profile = profileName
+func (r *reportBuilder) SetProfile(vendorType profiles.VendorType, version string) ReportBuilder {
+	r.Report.Metadata.ToolMetadata.Profile.VendorType = string(vendorType)
+	r.Report.Metadata.ToolMetadata.Profile.Version = version
 	return r
 }
 
@@ -80,8 +81,8 @@ func (r *reportBuilder) SetChart(chart *helmchart.Chart) ReportBuilder {
 	return r
 }
 
-func (r *reportBuilder) AddCheck(name checks.CheckName, checkType checks.CheckType, result checks.Result) ReportBuilder {
-	checkReport := r.Report.AddCheck(name, checkType)
+func (r *reportBuilder) AddCheck(check checks.Check, result checks.Result) ReportBuilder {
+	checkReport := r.Report.AddCheck(check)
 	checkReport.SetResult(result.Ok, result.Reason)
 	return r
 }

--- a/pkg/chartverifier/reportbuilder_test.go
+++ b/pkg/chartverifier/reportbuilder_test.go
@@ -1,6 +1,11 @@
 package chartverifier
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
@@ -40,6 +45,56 @@ func TestSha(t *testing.T) {
 				require.Equal(t, shas[chart], sha)
 			})
 		}
+	}
+
+}
+
+func TestFilePackageDigest(t *testing.T) {
+
+	charts := []string{"checks/chart-0.1.0-v3.with-csi.tgz",
+		"checks/chart-0.1.0-v3.valid.tgz",
+		"checks/chart-0.1.0-v2.invalid.tgz",
+		"checks/chart-0.1.0-v3.without-readme.tgz",
+		"checks/chart-0.1.0-v3.with-crd.tgz"}
+
+	for _, chart := range charts {
+		cmd := exec.Command("sha256sum", chart)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		err := cmd.Run()
+		if err != nil {
+			fmt.Println("error running command:")
+		}
+		commandResponse := strings.Split(out.String(), " ")
+		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
+	}
+
+}
+
+func TestUrlPackageDigest(t *testing.T) {
+
+	charts := []string{"https://github.com/redhat-certification/chart-verifier/blob/main/pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true",
+		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.13.0/hashicorp-vault-0.13.0.tgz",
+		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.12.0/hashicorp-vault-0.12.0.tgz",
+		"https://github.com/IBM/charts/blob/master/repo/ibm-helm/ibm-object-storage-plugin-2.1.2.tgz?raw=true"}
+
+	for _, chart := range charts {
+
+		var out bytes.Buffer
+		cmd1 := exec.Command("curl", "-L", chart)
+
+		cmd2 := exec.Command("sha256sum")
+
+		cmd2.Stdin, _ = cmd1.StdoutPipe()
+		cmd2.Stdout = &out
+
+		cmd2.Start()
+		cmd1.Run()
+		cmd2.Wait()
+
+		commandResponse := strings.Split(out.String(), " ")
+		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
+
 	}
 
 }

--- a/pkg/chartverifier/verifier.go
+++ b/pkg/chartverifier/verifier.go
@@ -18,6 +18,7 @@ package chartverifier
 
 import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/spf13/viper"
 	helmcli "helm.sh/helm/v3/pkg/cli"
 )
@@ -57,7 +58,7 @@ type verifier struct {
 	requiredChecks   []checks.Check
 	settings         *helmcli.EnvSettings
 	toolVersion      string
-	profileName      string
+	profile          *profiles.Profile
 	openshiftVersion string
 	values           map[string]interface{}
 }
@@ -81,7 +82,7 @@ func (c *verifier) Verify(uri string) (*Report, error) {
 		SetToolVersion(c.toolVersion).
 		SetChartUri(uri).
 		SetChart(chrt).
-		SetProfile(c.profileName)
+		SetProfile(c.profile.Vendor, c.profile.Version)
 
 	for _, check := range c.requiredChecks {
 
@@ -102,7 +103,7 @@ func (c *verifier) Verify(uri string) (*Report, error) {
 		if checkErr != nil {
 			return nil, NewCheckErr(checkErr)
 		}
-		_ = result.AddCheck(check.CheckId.Name, check.Type, r)
+		_ = result.AddCheck(check, r)
 
 	}
 

--- a/pkg/chartverifier/verifier_test.go
+++ b/pkg/chartverifier/verifier_test.go
@@ -19,6 +19,7 @@ package chartverifier
 import (
 	"context"
 	"errors"
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -67,6 +68,7 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:       cli.New(),
 			config:         viper.New(),
+			profile:        profiles.Get(),
 			registry:       checks.NewRegistry(),
 			requiredChecks: []checks.Check{dummyCheck},
 		}
@@ -81,6 +83,7 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:       cli.New(),
 			config:         viper.New(),
+			profile:        profiles.Get(),
 			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", erroredCheck),
 			requiredChecks: []checks.Check{dummyCheck},
 		}
@@ -95,6 +98,7 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:         cli.New(),
 			config:           viper.New(),
+			profile:          profiles.Get(),
 			registry:         checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", negativeCheck),
 			requiredChecks:   []checks.Check{dummyCheck},
 			openshiftVersion: "4.9",
@@ -111,6 +115,7 @@ func TestVerifier_Verify(t *testing.T) {
 		c := &verifier{
 			settings:       cli.New(),
 			config:         viper.New(),
+			profile:        profiles.Get(),
 			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
 			requiredChecks: []checks.Check{dummyCheck},
 		}


### PR DESCRIPTION
Added package sha to the report for tgz charts. The code for calculating the sha value was basically copied from helm code:

- https://github.com/helm/helm/blob/eb99434597d230a2106b22f15ac1e250ca5592f6/pkg/provenance/sign.go#L391
- https://github.com/helm/helm/blob/eb99434597d230a2106b22f15ac1e250ca5592f6/pkg/provenance/sign.go#L403

The package sha is added in the report:
```
        digest: sha256:0f84c30a7f18cf9adcfc5481b59755a71b555c8f420b41dc49360c4ba473892e
        digests:
            chart: sha256:0f84c30a7f18cf9adcfc5481b59755a71b555c8f420b41dc49360c4ba473892e
            package: 97e274069d9d3d028903610a3f9fca892b2620f0a334de6215ec5f962328586f
```

```digest:``` is left for backwards compatability and can be removed in the future.

If the report was run against chart src the digests.package attribute will be omitted. 


Tests included check that the calculated package sha matches the value return from ```sha256sum``` for local charts and ```curl -L <url> | sha256sum" for remote charts.

Also I verified the sha's caclulated for the currently published charts match the values currently in https://github.com/openshift-helm-charts/charts/blob/gh-pages/index.yaml




