### PR TITLE
Calculate package sha values

### DIFF
--- a/pkg/chartverifier/report.go
+++ b/pkg/chartverifier/report.go
@@ -49,7 +49,7 @@ type ToolMetadata struct {
 	Version                    string  `json:"verifier-version" yaml:"verifier-version"`
 	Profile                    string  `json:"profileName" yaml:"profileName"`
 	ChartUri                   string  `json:"chart-uri" yaml:"chart-uri"`
-	Digest                     string  `json:"digest,omitempty" yaml:"digest"`
+	Digest                     string  `json:"digest" yaml:"digest"`
 	Digests                    Digests `json:"digests" yaml:"digests"`
 	LastCertifiedTimestamp     string  `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
 	CertifiedOpenShiftVersions string  `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`

--- a/pkg/chartverifier/report.go
+++ b/pkg/chartverifier/report.go
@@ -46,12 +46,18 @@ type ReportMetadata struct {
 }
 
 type ToolMetadata struct {
-	Version                    string `json:"verifier-version" yaml:"verifier-version"`
-	Profile                    string `json:"profileName" yaml:"profileName"`
-	ChartUri                   string `json:"chart-uri" yaml:"chart-uri"`
-	Digest                     string `json:"digest,omitempty" yaml:"digest,omitempty"`
-	LastCertifiedTimestamp     string `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
-	CertifiedOpenShiftVersions string `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`
+	Version                    string  `json:"verifier-version" yaml:"verifier-version"`
+	Profile                    string  `json:"profileName" yaml:"profileName"`
+	ChartUri                   string  `json:"chart-uri" yaml:"chart-uri"`
+	Digest                     string  `json:"digest,omitempty" yaml:"digest"`
+	Digests                    Digests `json:"digests" yaml:"digests"`
+	LastCertifiedTimestamp     string  `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
+	CertifiedOpenShiftVersions string  `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`
+}
+
+type Digests struct {
+	Chart   string `json:"chart" yaml:"chart"`
+	Package string `json:"package,omitempty" yaml:"package,omitempty"`
 }
 
 type CheckReport struct {

--- a/pkg/chartverifier/reportbuilder_test.go
+++ b/pkg/chartverifier/reportbuilder_test.go
@@ -71,29 +71,16 @@ func TestFilePackageDigest(t *testing.T) {
 
 func TestUrlPackageDigest(t *testing.T) {
 
-	charts := []string{"https://github.com/redhat-certification/chart-verifier/blob/main/pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true",
-		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.13.0/hashicorp-vault-0.13.0.tgz",
-		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.12.0/hashicorp-vault-0.12.0.tgz",
-		"https://github.com/IBM/charts/blob/master/repo/ibm-helm/ibm-object-storage-plugin-2.1.2.tgz?raw=true"}
+	charts := make(map[string]string)
 
-	for _, chart := range charts {
+	charts["https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.13.0/hashicorp-vault-0.13.0.tgz"] = "97e274069d9d3d028903610a3f9fca892b2620f0a334de6215ec5f962328586f"
+	charts["https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.12.0/hashicorp-vault-0.12.0.tgz"] = "b07be2a554ecbe6a6dd48ea763ed568de317d17cf1a19fb11ddb562983286555"
+	charts["https://github.com/IBM/charts/blob/master/repo/ibm-helm/ibm-object-storage-plugin-2.1.2.tgz?raw=true"] = "06efa1e26f8a7ba93a6e6136650b0624af2558cc44a4588198fca322f9219e32"
+	charts["https://github.com/redhat-certification/chart-verifier/blob/main/pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true"] = "4f29f2a95bf2b9a1c62fd215b079a01bdc5a38e9b4ff874d0fa21d0afca2e76d"
 
-		var out bytes.Buffer
-		cmd1 := exec.Command("curl", "-L", chart)
-		cmd2 := exec.Command("sha256sum")
+	for chart, sha := range charts {
 
-		var err error
-		cmd2.Stdin, err = cmd1.StdoutPipe()
-		assert.NoError(t, err, "error get pipe from curl -L command")
-		cmd2.Stdout = &out
-		err = cmd2.Start()
-		assert.NoError(t, err, "error starting sha256sum command")
-		err = cmd1.Run()
-		assert.NoError(t, err, "error starting curl -L command")
-		err = cmd2.Wait()
-		assert.NoError(t, err, "error waiting for sha256sum command")
-		commandResponse := strings.Split(out.String(), " ")
-		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
+		assert.Equal(t, sha, GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
 
 	}
 

--- a/pkg/chartverifier/reportbuilder_test.go
+++ b/pkg/chartverifier/reportbuilder_test.go
@@ -1,6 +1,11 @@
 package chartverifier
 
 import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
@@ -40,6 +45,56 @@ func TestSha(t *testing.T) {
 				require.Equal(t, shas[chart], sha)
 			})
 		}
+	}
+
+}
+
+func TestFilePackageDigest(t *testing.T) {
+
+	charts := []string{"checks/chart-0.1.0-v3.with-csi.tgz",
+		"checks/chart-0.1.0-v3.valid.tgz",
+		"checks/chart-0.1.0-v2.invalid.tgz",
+		"checks/chart-0.1.0-v3.without-readme.tgz",
+		"checks/chart-0.1.0-v3.with-crd.tgz"}
+
+	for _, chart := range charts {
+		cmd := exec.Command("sha256sum", chart)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		err := cmd.Run()
+		if err != nil {
+			fmt.Println("error running command:")
+		}
+		commandResponse := strings.Split(out.String(), " ")
+		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
+	}
+
+}
+
+func TestUrlPackageDigest(t *testing.T) {
+
+	charts := []string{"https://github.com/redhat-certification/chart-verifier/blob/main/pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true",
+		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.13.0/hashicorp-vault-0.13.0.tgz",
+		"https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.12.0/hashicorp-vault-0.12.0.tgz",
+		"https://github.com/IBM/charts/blob/master/repo/ibm-helm/ibm-object-storage-plugin-2.1.2.tgz?raw=true"}
+
+	for _, chart := range charts {
+
+		var out bytes.Buffer
+		cmd1 := exec.Command("curl", "-L", chart)
+
+		cmd2 := exec.Command("sha256sum")
+
+		cmd2.Stdin, _ = cmd1.StdoutPipe()
+		cmd2.Stdout = &out
+
+		cmd2.Start()
+		cmd1.Run()
+		cmd2.Wait()
+
+		commandResponse := strings.Split(out.String(), " ")
+		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
+
 	}
 
 }


### PR DESCRIPTION
Added package sha to the report for tgz charts. The code for calculating the sha value was basically copied from helm code:

- https://github.com/helm/helm/blob/eb99434597d230a2106b22f15ac1e250ca5592f6/pkg/provenance/sign.go#L391
- https://github.com/helm/helm/blob/eb99434597d230a2106b22f15ac1e250ca5592f6/pkg/provenance/sign.go#L403

The package sha is added in the report:
```
        digest: sha256:0f84c30a7f18cf9adcfc5481b59755a71b555c8f420b41dc49360c4ba473892e
        digests:
            chart: sha256:0f84c30a7f18cf9adcfc5481b59755a71b555c8f420b41dc49360c4ba473892e
            package: 97e274069d9d3d028903610a3f9fca892b2620f0a334de6215ec5f962328586f
```

```digest:``` is left for backwards compatability and can be removed in the future.

If the report was run against chart src the digests.package attribute will be omitted. 


Tests included check that the calculated package sha matches the value return from ```sha256sum``` for local charts and ```curl -L <url> | sha256sum" for remote charts.

Also I verified the sha's caclulated for the currently published charts match the values currently in https://github.com/openshift-helm-charts/charts/blob/gh-pages/index.yaml
