### PR TITLE
use default profile from docker image and bump version to 1.0.1

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -34,7 +34,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
 )
 
-var Version = "1.0.0"
+var Version = "1.0.1"
 
 func init() {
 	allChecks = chartverifier.DefaultRegistry().AllChecks()

--- a/pkg/chartverifier/profiles/default.go
+++ b/pkg/chartverifier/profiles/default.go
@@ -11,7 +11,10 @@ func getDefaultProfile(msg string) *Profile {
 	profile.Apiversion = "v1"
 	profile.Kind = "verifier-profile"
 
-	profile.Name = fmt.Sprintf("default-profile : %s", msg)
+	profile.Name = "default-profile"
+	if len(msg) > 0 {
+		profile.Name = fmt.Sprintf("%s : %s", profile.Name, msg)
+	}
 
 	profile.Annotations = []Annotation{DigestAnnotation, OCPVersionAnnotation, LastCertifiedTimestampAnnotation}
 
@@ -28,8 +31,6 @@ func getDefaultProfile(msg string) *Profile {
 		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ImagesAreCertifiedName), Type: checks.MandatoryCheckType},
 		{Name: fmt.Sprintf("%s/%s", "v1.0", checks.ChartTestingName), Type: checks.MandatoryCheckType},
 	}
-
-	profile.Name = fmt.Sprintf("default-profile : %s", msg)
 
 	return &profile
 }

--- a/pkg/chartverifier/profiles/profile.go
+++ b/pkg/chartverifier/profiles/profile.go
@@ -42,6 +42,11 @@ func Get() *Profile {
 		return profile
 	}
 
+	if isRunningInDockerContainer() {
+		profile = getDefaultProfile("")
+		return profile
+	}
+
 	fileName, err := getProfileFileName()
 	if err != nil {
 		profile = getDefaultProfile(err.Error())
@@ -97,4 +102,15 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 
 	return filteredChecks
 
+}
+
+func isRunningInDockerContainer() bool {
+	// docker creates a .dockerenv file at the root
+	// of the directory tree inside the container.
+	// if this file exists then verifier is running
+	// from inside a container
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
1. Bumped chart verifier version to 1.0.1 ready for release.
2. If running a docker image use the default profile (same as partner profile). This is a temp fix until multi-profiles is added.