### PR TITLE
fix annotation names in report

### DIFF
--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -16,9 +16,9 @@ import (
 func TestReport(t *testing.T) {
 
 	var expectedAnnotations []report.Annotation
-	annotation1 := report.Annotation{Name: fmt.Sprintf("%s/Digest", report.DefaultAnnotationsPrefix), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"}
-	annotation2 := report.Annotation{Name: fmt.Sprintf("%s/OCPVersion", report.DefaultAnnotationsPrefix), Value: "4.7.8"}
-	annotation3 := report.Annotation{Name: fmt.Sprintf("%s/LastCertifiedTimestamp", report.DefaultAnnotationsPrefix), Value: "2021-07-06T10:28:01.09604-04:00"}
+	annotation1 := report.Annotation{Name: fmt.Sprintf("%s/%s", report.DefaultAnnotationsPrefix, report.DigestsAnnotationName), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"}
+	annotation2 := report.Annotation{Name: fmt.Sprintf("%s/%s", report.DefaultAnnotationsPrefix, report.CertifiedOCPVersionAnnotationName), Value: "4.7.8"}
+	annotation3 := report.Annotation{Name: fmt.Sprintf("%s/%s", report.DefaultAnnotationsPrefix, report.LastCertifiedTimestampAnnotationName), Value: "2021-07-06T10:28:01.09604-04:00"}
 	expectedAnnotations = append(expectedAnnotations, annotation1, annotation2, annotation3)
 
 	expectedResults := &report.ResultsReport{}
@@ -181,9 +181,9 @@ func TestReport(t *testing.T) {
 		require.NoError(t, cmd.Execute())
 
 		var expectedPrefixAnnotations []report.Annotation
-		annotationP1 := report.Annotation{Name: fmt.Sprintf("%s/Digest", annotationPrefix), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"}
-		annotationP2 := report.Annotation{Name: fmt.Sprintf("%s/OCPVersion", annotationPrefix), Value: "4.7.8"}
-		annotationP3 := report.Annotation{Name: fmt.Sprintf("%s/LastCertifiedTimestamp", annotationPrefix), Value: "2021-07-06T10:28:01.09604-04:00"}
+		annotationP1 := report.Annotation{Name: fmt.Sprintf("%s/%s", annotationPrefix, report.DigestsAnnotationName), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"}
+		annotationP2 := report.Annotation{Name: fmt.Sprintf("%s/%s", annotationPrefix, report.CertifiedOCPVersionAnnotationName), Value: "4.7.8"}
+		annotationP3 := report.Annotation{Name: fmt.Sprintf("%s/%s", annotationPrefix, report.LastCertifiedTimestampAnnotationName), Value: "2021-07-06T10:28:01.09604-04:00"}
 		expectedPrefixAnnotations = append(expectedPrefixAnnotations, annotationP1, annotationP2, annotationP3)
 
 		testReport := report.OutputReport{}

--- a/pkg/chartverifier/report/reporter.go
+++ b/pkg/chartverifier/report/reporter.go
@@ -17,6 +17,10 @@ const (
 	AnnotationsPrefixConfigName string = "annotations.prefix"
 
 	DefaultAnnotationsPrefix string = "charts.openshift.io"
+
+	DigestsAnnotationName                string = "digests"
+	LastCertifiedTimestampAnnotationName string = "lastCertifiedTimestamp"
+	CertifiedOCPVersionAnnotationName    string = "certifiedOpenShiftVersions"
 )
 
 func All(opts *ReportOptions) (OutputReport, error) {
@@ -65,7 +69,7 @@ func Annotations(opts *ReportOptions) (OutputReport, error) {
 		}
 	}
 
-	name := fmt.Sprintf("%s/%s", anotationsPrefix, profiles.DigestAnnotation)
+	name := fmt.Sprintf("%s/%s", anotationsPrefix, DigestsAnnotationName)
 	value := report.Metadata.ToolMetadata.Digest
 	if len(value) > 0 {
 		annotation := Annotation{}
@@ -74,7 +78,7 @@ func Annotations(opts *ReportOptions) (OutputReport, error) {
 		outputReport.AnnotationsReport = append(outputReport.AnnotationsReport, annotation)
 	}
 
-	name = fmt.Sprintf("%s/%s", anotationsPrefix, profiles.LastCertifiedTimestampAnnotation)
+	name = fmt.Sprintf("%s/%s", anotationsPrefix, LastCertifiedTimestampAnnotationName)
 	value = report.Metadata.ToolMetadata.LastCertifiedTimestamp
 	if len(value) > 0 {
 		annotation := Annotation{}
@@ -83,7 +87,7 @@ func Annotations(opts *ReportOptions) (OutputReport, error) {
 		outputReport.AnnotationsReport = append(outputReport.AnnotationsReport, annotation)
 	}
 
-	name = fmt.Sprintf("%s/%s", anotationsPrefix, profiles.OCPVersionAnnotation)
+	name = fmt.Sprintf("%s/%s", anotationsPrefix, CertifiedOCPVersionAnnotationName)
 	value = report.Metadata.ToolMetadata.CertifiedOpenShiftVersions
 	if len(value) > 0 {
 		annotation := Annotation{}

--- a/pkg/chartverifier/report/reporter_test.go
+++ b/pkg/chartverifier/report/reporter_test.go
@@ -22,9 +22,9 @@ func TestReports(t *testing.T) {
 	testPartnerMetaDataReport.ProfileVendorType = "partner"
 
 	var testAnnotationsReport []Annotation
-	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: "charts.openshift.io/Digest", Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"})
-	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: "charts.openshift.io/LastCertifiedTimestamp", Value: "2021-07-02T08:09:56.881793-04:00"})
-	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: "charts.openshift.io/OCPVersion", Value: "4.7.8"})
+	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: fmt.Sprintf("charts.openshift.io/%s", DigestsAnnotationName), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"})
+	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: fmt.Sprintf("charts.openshift.io/%s", LastCertifiedTimestampAnnotationName), Value: "2021-07-02T08:09:56.881793-04:00"})
+	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: fmt.Sprintf("charts.openshift.io/%s", CertifiedOCPVersionAnnotationName), Value: "4.7.8"})
 
 	testDigestReport := &DigestReport{}
 	testDigestReport.PackageDigest = "4f29f2a95bf2b9a1c62fd215b079a01bdc5a38e9b4ff874d0fa21d0afca2e76d"
@@ -98,9 +98,9 @@ func TestReports(t *testing.T) {
 	setBehaviorTestInfo.expectedReport.ResultsReport.Failed = "0"
 	setBehaviorTestInfo.annotationsPrefix = "test.report.command.io"
 	var setBehaviorAnnotationsReport []Annotation
-	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/Digest", setBehaviorTestInfo.annotationsPrefix), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"})
-	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/LastCertifiedTimestamp", setBehaviorTestInfo.annotationsPrefix), Value: "2021-07-02T08:09:56.881793-04:00"})
-	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/OCPVersion", setBehaviorTestInfo.annotationsPrefix), Value: "4.7.8"})
+	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/%s", setBehaviorTestInfo.annotationsPrefix, DigestsAnnotationName), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"})
+	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/%s", setBehaviorTestInfo.annotationsPrefix, LastCertifiedTimestampAnnotationName), Value: "2021-07-02T08:09:56.881793-04:00"})
+	setBehaviorAnnotationsReport = append(setBehaviorAnnotationsReport, Annotation{Name: fmt.Sprintf("%s/%s", setBehaviorTestInfo.annotationsPrefix, CertifiedOCPVersionAnnotationName), Value: "4.7.8"})
 	setBehaviorTestInfo.expectedReport.AnnotationsReport = setBehaviorAnnotationsReport
 	setBehaviorTestInfo.expectedReport.MetadataReport = testPartnerMetaDataReport
 	tests = append(tests, setBehaviorTestInfo)


### PR DESCRIPTION
Annotation names were wrong the reports, started with upper case letters etc..
Fixed the report and associated tests. 

Was:
```
annotations:
  - name: charts.openshift.io/Digest
    value: sha256:e7cacf93d397b58c64f9c113cc0671e6e920022bf4227cab291e18c6e3827954
  - name: charts.openshift.io/LastCertifiedTimestamp
    value: "2021-07-14T12:56:47.06869-04:00"
  - name: charts.openshift.io/OCPVersion
    value: N/A
```

now:
```
annotations:
  - name: charts.openshift.io/digests
    value: sha256:e7cacf93d397b58c64f9c113cc0671e6e920022bf4227cab291e18c6e3827954
  - name: charts.openshift.io/lastCertifiedTimestamp
    value: "2021-07-14T12:56:47.06869-04:00"
  - name: charts.openshift.io/certifiedOpenShiftVersions
    value: N/A
````