### PR TITLE
add chart-uri and chart to report command metadata output

### DIFF
--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	helmchart "helm.sh/helm/v3/pkg/chart"
 	"strconv"
 	"strings"
 	"testing"
@@ -28,6 +29,8 @@ func TestReport(t *testing.T) {
 	expectedMetadata := &report.MetadataReport{}
 	expectedMetadata.ProfileVersion = "v1.0"
 	expectedMetadata.ProfileVendorType = "redhat"
+	expectedMetadata.ChartUri = "pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz"
+	expectedMetadata.Chart = &helmchart.Metadata{Name: "chart", Version: "0.1.0-v3.valid"}
 
 	expectedDigests := &report.DigestReport{}
 	expectedDigests.PackageDigest = "4f29f2a95bf2b9a1c62fd215b079a01bdc5a38e9b4ff874d0fa21d0afca2e76d"
@@ -248,6 +251,18 @@ func compareMetadata(expected *report.MetadataReport, result *report.MetadataRep
 	}
 	if expected.ProfileVendorType != result.ProfileVendorType {
 		fmt.Println(fmt.Sprintf("profile vendortype mistmatch %s : %s", expected.ProfileVendorType, result.ProfileVendorType))
+		outcome = false
+	}
+	if expected.ChartUri != result.ChartUri {
+		fmt.Println(fmt.Sprintf("chart uri mistmatch %s : %s", expected.ChartUri, result.ChartUri))
+		outcome = false
+	}
+	if expected.Chart.Name != result.Chart.Name {
+		fmt.Println(fmt.Sprintf("chart name mistmatch %s : %s", expected.Chart.Name, result.Chart.Name))
+		outcome = false
+	}
+	if expected.Chart.Version != result.Chart.Version {
+		fmt.Println(fmt.Sprintf("chart version mistmatch %s : %s", expected.Chart.Version, result.Chart.Version))
 		outcome = false
 	}
 	return outcome

--- a/pkg/chartverifier/report/output.go
+++ b/pkg/chartverifier/report/output.go
@@ -1,6 +1,9 @@
 package report
 
-import "github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
+import (
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+)
 
 type OutputReport struct {
 	AnnotationsReport []Annotation    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
@@ -22,6 +25,8 @@ type DigestReport struct {
 type MetadataReport struct {
 	ProfileVendorType profiles.VendorType `json:"vendorType" yaml:"vendorType"`
 	ProfileVersion    string              `json:"profileVersion" yaml:"profileVersion"`
+	ChartUri          string              `json:"chart-uri" yaml:"chart-uri"`
+	Chart             *helmchart.Metadata `json:"chart" yaml:"chart"`
 }
 
 type ResultsReport struct {

--- a/pkg/chartverifier/report/reporter.go
+++ b/pkg/chartverifier/report/reporter.go
@@ -131,6 +131,8 @@ func Metadata(opts *ReportOptions) (OutputReport, error) {
 
 	outputReport.MetadataReport.ProfileVendorType = profiles.VendorType(report.Metadata.ToolMetadata.Profile.VendorType)
 	outputReport.MetadataReport.ProfileVersion = report.Metadata.ToolMetadata.Profile.Version
+	outputReport.MetadataReport.ChartUri = report.Metadata.ToolMetadata.ChartUri
+	outputReport.MetadataReport.Chart = report.Metadata.ChartData
 	return outputReport, nil
 
 }

--- a/pkg/chartverifier/report/reporter_test.go
+++ b/pkg/chartverifier/report/reporter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	helmchart "helm.sh/helm/v3/pkg/chart"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,10 +17,14 @@ func TestReports(t *testing.T) {
 	testRedHatMetaDataReport := &MetadataReport{}
 	testRedHatMetaDataReport.ProfileVersion = "v1.0"
 	testRedHatMetaDataReport.ProfileVendorType = "redhat"
+	testRedHatMetaDataReport.ChartUri = "pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz"
+	testRedHatMetaDataReport.Chart = &helmchart.Metadata{Name: "chart", Version: "0.1.0-v3.valid"}
 
 	testPartnerMetaDataReport := &MetadataReport{}
 	testPartnerMetaDataReport.ProfileVersion = "v1.0"
 	testPartnerMetaDataReport.ProfileVendorType = "partner"
+	testPartnerMetaDataReport.ChartUri = "pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz"
+	testPartnerMetaDataReport.Chart = &helmchart.Metadata{Name: "chart", Version: "0.1.0-v3.valid"}
 
 	var testAnnotationsReport []Annotation
 	testAnnotationsReport = append(testAnnotationsReport, Annotation{Name: fmt.Sprintf("charts.openshift.io/%s", DigestsAnnotationName), Value: "sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0"})
@@ -207,6 +212,19 @@ func CompareMetadata(expected *MetadataReport, result *MetadataReport) bool {
 		fmt.Println(fmt.Sprintf("profile vendortype mistmatch %s : %s", expected.ProfileVendorType, result.ProfileVendorType))
 		outcome = false
 	}
+	if expected.ChartUri != result.ChartUri {
+		fmt.Println(fmt.Sprintf("chart uri mistmatch %s : %s", expected.ChartUri, result.ChartUri))
+		outcome = false
+	}
+	if expected.Chart.Name != result.Chart.Name {
+		fmt.Println(fmt.Sprintf("chart name mistmatch %s : %s", expected.Chart.Name, result.Chart.Name))
+		outcome = false
+	}
+	if expected.Chart.Version != result.Chart.Version {
+		fmt.Println(fmt.Sprintf("chart version mistmatch %s : %s", expected.Chart.Version, result.Chart.Version))
+		outcome = false
+	}
+
 	return outcome
 }
 


### PR DESCRIPTION
added chart-uri and chart metdata to the outout of report metadata, for example: 
```
metadata:
    vendorType: redhat
    profileVersion: v1.0
    chart-uri: ../../test/ibm-oms-pro-prod-6.0.1.tgz
    chart:
        name: ibm-oms-pro-prod
        home: http://ibm.biz/oms-home
        sources: []
        version: 6.0.1
       etc...
```

This addresses 2 problems.
1. workflow uses chart-uri and chart.name and chart.version from the verifier report and as a result hard codes to the verifier report format. Using the report command makes the workflow independant of verifier report format.
2. Because the workflow works based on json format and by getting the chart data from the report command in json format, empty fields are not included  which automagically fixes the importvalues problem: https://issues.redhat.com/browse/HELM-210