### PR TITLE
add new version support: prep for release automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,6 @@ COPY --from=build /usr/local/bin/* /usr/local/bin/
 
 COPY ./config /app/config
 
+COPY cmd/release /app/releases
+
 ENTRYPOINT ["/app/chart-verifier"]

--- a/cmd/release/release_info.json
+++ b/cmd/release/release_info.json
@@ -1,0 +1,7 @@
+{
+    "version": "1.2.1",
+    "quay-image":  "quay.io/redhat-certification/chart-verifier",
+    "release-info": [
+        "Update for security vulnerability."
+    ]
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -34,8 +34,6 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
 )
 
-var Version = "1.1.0"
-
 func init() {
 	allChecks = chartverifier.DefaultRegistry().AllChecks()
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,1 +1,68 @@
 package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var Version = "0.0.0"
+
+type Release struct {
+	Version string `json:"version"`
+}
+
+func init() {
+
+	var configDir string
+	if isRunningInDockerContainer() {
+		configDir = filepath.Join("app", "releases")
+	} else {
+		_, fn, _, ok := runtime.Caller(0)
+		if !ok {
+			return
+		}
+		index := strings.LastIndex(fn, "chart-verifier/")
+		configDir = fn[0 : index+len("chart-verifier")]
+		configDir = filepath.Join(configDir, "cmd", "release")
+	}
+
+	jsonFile, err := os.Open(filepath.Join(configDir, "release_info.json"))
+	if err != nil {
+		Version = "0.0.1"
+		return
+	}
+
+	// read our opened jsonFile as a byte array.
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		Version = "0.0.2"
+		return
+	}
+
+	var release Release
+	// we unmarshal our byteArray which contains our
+	// jsonFile's content into 'users' which we defined above
+	err = json.Unmarshal(byteValue, &release)
+	if err != nil {
+		Version = "0.0.3"
+		return
+	}
+
+	Version = release.Version
+
+}
+
+func isRunningInDockerContainer() bool {
+	// docker creates a .dockerenv file at the root
+	// of the directory tree inside the container.
+	// if this file exists then verifier is running
+	// from inside a container
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	return false
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+
+	t.Run("Check Version is set.", func(t *testing.T) {
+		fmt.Println(fmt.Sprintf("Version is %s", Version))
+		require.True(t, semver.IsValid("v"+Version), fmt.Sprintf("Version is not a valid semantic version: %s", Version))
+		require.True(t, semver.Compare("v"+Version, "v.0.0.3") > 0, fmt.Sprintf("Version has not been set: %s", Version))
+	})
+
+}


### PR DESCRIPTION
Add support for reading the chart verifier version from a json file in preparation for release automation. 