### PR TITLE
add latest tag to new image in quay

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -140,3 +140,12 @@ jobs:
                 body: ${{ steps.check_version_in_PR.outputs.PR_release_body }}
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Check and link latest image in quay
+              id: link_image_in_qauy
+              if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
+              env:
+                QUAY_AUTH_TOKEN: ${{ secrets.QUAY_AUTH_TOKEN }}
+              run: |
+                # Check and link latest image to latest release if needed
+                ve1/bin/link-images --verifier-version=${{ steps.check_version_in_PR.outputs.PR_version }} --link-tag="latest"

--- a/docs/helm-chart-release.md
+++ b/docs/helm-chart-release.md
@@ -25,14 +25,21 @@ Chart verifier - release creation is automated through a git hub workflow. To cr
    - The PR does not contain any other files.
    - The submitter has approval authority for the repository.
    - All tests pass. 
-    
-1. Once the release is created, quay will detect the release and build a docker image for the release. 
-    - see [chart verifier tags in quay](https://quay.io/repository/redhat-certification/chart-verifier?tab=tags)
 
-1. Once the image is in quay the latest image mut be reset to point to the new release:
-   1. For the new image hit the options icon on the far right
-   1. A drop down list appears, select "add a new tag" 
-   1. A dialogue appears, enter the new tag name as "latest" 
-   1. Quay detects latest is laready in use, select "Move" so it points to the new release.
+1. After merging the PR and creating the release the workflow continues in an attempt to add the ```latest``` tag to the new chart verifier image in quay. This may take a while.      
+
+   - When the release is created, quay will detect the release and build a docker image for the release. 
+        - see [chart verifier image tags in quay](https://quay.io/repository/redhat-certification/chart-verifier?tab=tags)
+   - The workflow retries for up to 15 minutes for the docker image to appear in quay so that it can be linked. If this fails it can be done manually:
+        1. Navigate to the [chart verifier image tags in quay](https://quay.io/repository/redhat-certification/chart-verifier?tab=tags)
+            1. For the new image hit the options icon on the far right
+            1. A drop down list appears, select "add a new tag" 
+            1. A dialogue appears, enter the new tag name as "latest" 
+            1. Quay detects latest is laready in use, select "Move" so it points to the new release.
    
-    Note: it is intended to automate this step in the future. 
+Notes:
+- To link the image to the ```latest``` tag in quay an auth token is required. This must be set as a repository secret "QUAY_AUTH_TOKEN"
+    - For information on creating an auth token see: [Red Hat Quay API guide](https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/red_hat_quay_api_guide/using_the_red_hat_quay_api) 
+    - The workflow uses the [ChartVerfifierReleaser OAuth Applictaion](https://quay.io/organization/redhat-certification?tab=applications). 
+      - If the application auth token is changed for any reason the repository secret must also be updated.
+    

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -26,3 +26,4 @@ toml==0.10.2
 urllib3==1.26.5
 docker==5.0.0
 six==1.16.0
+retry==0.9.2

--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -39,3 +39,4 @@ console_scripts =
     check-auto-merge = checkautomerge.checkautomerge:main
     build-and-test = buildandtest.buildandtest:main
     check-user = owners.checkuser:main
+    link-images = quay.linkimages:main

--- a/scripts/src/quay/linkimages.py
+++ b/scripts/src/quay/linkimages.py
@@ -1,0 +1,133 @@
+"""
+Used by a github action to link a newly published chart verifier image to a specified tag in quay
+Can also be called from the command line.
+
+parameters:
+    ---link-tag : tag to link the image to, default is "test"
+    --verifier-version : the version of the new chart verifier release
+
+notes:
+    It is anticipated that the github action will invoke this function just before the new image is available
+    in quay. As a result the function will look for the image every 15 seconds for up to 15 minutes.
+
+    To invoke from the command line, invoke from the root directory of the repository,for example:
+          python3 scripts/src/quay/linkimages.py --verifier-version=1.2.0.
+
+    If the verifier version image is already linked to the specified tag no action is taken.
+
+    The default of link-tag is set to "test" to avoid accidental updates to latest.
+
+    The auth token to enable the script to link tags in quay must be set in an environment variable QUAY_AUTH_TOKEN.
+    For a github action this must be set as a repository secret.
+    For information on auth token required see:
+    https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/red_hat_quay_api_guide/using_the_red_hat_quay_api
+
+results:
+    A message indicating the outcome.
+    exit code 1 if version image was not found.
+
+"""
+
+import requests
+import json
+import sys
+import argparse
+import os
+from retry import retry
+
+sys.path.append('./scripts/src/')
+from release import releasechecker
+
+# Quay API docs: https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/red_hat_quay_api_guide/index
+# Quay Swagger API: https://docs.quay.io/api/swagger/
+#
+
+defaultLinkTag= "test"
+tagUrl = 'https://quay.io/api/v1/repository/redhat-certification/chart-verifier/tag/'
+
+# try every 15 seconds for 15 minutes
+@retry(Exception,tries=60, delay=15)
+def getImageId(tagValue,doRetry):
+
+    print(f"[INFO] look for tag : {tagValue}, retry : {doRetry}")
+    tagUrl = 'https://quay.io/api/v1/repository/redhat-certification/chart-verifier/tag/'
+
+    get_params = {'onlyActiveTags' : 'true','specificTag' : tagValue }
+
+    response = requests.get(tagUrl,params=get_params)
+
+    imageId = ""
+    if response.status_code > 201:
+        print(f"[Error] Error getting tags from quay : status_code={response.status_code}")
+    else:
+        tags = json.loads(response.text)
+        print("[INFO] loaded the tags")
+        for tag in tags["tags"]:
+            if tag['name'] == tagValue:
+                imageId = tag['image_id']
+                print(f"[INFO] Found tag {tagValue}. image_id : {imageId}")
+                break
+            else:
+                print(f"[INFO] ignore tag {tag['name']}")
+
+        if not imageId and doRetry:
+            print(f"[INFO] {tagValue} not found. Retry!")
+            raise Exception(f"Image {tagValue} not found")
+
+    return imageId
+
+def linkImage(linkImage,linkTag):
+
+    print(f"[INFO] Update {linkTag} to point to {linkImage}")
+    auth_token = os.environ.get('QUAY_AUTH_TOKEN')
+    if auth_token is None:
+        print("[ERROR] repository secret QUAY_AUTH_TOKEN not set")
+        return False
+
+    quay_token = f"Bearer {auth_token}"
+    put_header = {'content-type': 'application/json','Authorization': quay_token}
+
+    puturl = tagUrl + linkTag
+    putData = {'image': linkImage}
+    putOut = requests.put(puturl,data=json.dumps(putData), headers=put_header)
+    print(f"[INFO] Update link response code : {putOut.status_code}")
+    print(f"[INFO] Update link response : {putOut.text}")
+
+    return putOut.status_code == 200 or putOut.status_code == 201
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--link-tag", dest="link_tag", type=str, required=False, default=defaultLinkTag,
+                        help="Tag image should be linked to (default: test")
+    parser.add_argument("-v", "--verifier-version", dest="verifier_version", type=str, required=False,
+                        help="New version of chart verifier")
+    args = parser.parse_args()
+
+    newTag = args.verifier_version
+    if args.verifier_version is None:
+        version_info = releasechecker.get_version_info()
+        newTag = version_info["version"]
+
+    try:
+        newImageId = getImageId(newTag,True)
+        tagImageId = getImageId(args.link_tag,False)
+        if tagImageId != newImageId:
+            if linkImage(newImageId,args.link_tag):
+                print(f"[INFO] PASS {args.link_tag} linked to {newTag}")
+                return
+            else:
+                print(f"[ERROR] Failed to link tags")
+                sys.exit(1)
+        else:
+            print(f"[INFO] Tag {args.link_tag} is current")
+            return
+    except Exception as inst:
+        print(f"[WARNING] {inst.args}")
+        sys.exit(1)
+
+    return
+
+if __name__ == "__main__":
+    main()

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -68,10 +68,10 @@ def make_release_body(version, image_name, release_info):
     print(f"::set-output name=PR_release_body::{body}")
 
 def get_version_info():
-    file = open(VERSION_FILE,)
-    jsonData = json.load(file)
-    file.close()
-    return jsonData
+    data = {}
+    with open(VERSION_FILE) as json_file:
+        data = json.load(json_file)
+    return data
 
 def main():
     parser = argparse.ArgumentParser()

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -67,6 +67,11 @@ def make_release_body(version, image_name, release_info):
     print(f"[INFO] Release body: {body}")
     print(f"::set-output name=PR_release_body::{body}")
 
+def get_version_info():
+    file = open(VERSION_FILE,)
+    jsonData = json.load(file)
+    file.close()
+    return jsonData
 
 def main():
     parser = argparse.ArgumentParser()
@@ -78,18 +83,15 @@ def main():
     args = parser.parse_args()
     if args.api_url and check_if_only_version_file_is_modified(args.api_url):
         ## should be on PR branch
-        file = open(VERSION_FILE, )
-        version_info = json.load(file)
+        version_info = get_version_info()
         print(f'[INFO] Release found in PR files : {version_info["version"]}.')
         print(f'::set-output name=PR_version::{version_info["version"]}')
         print(f'::set-output name=PR_release_image::{version_info["quay-image"]}')
         print(f'::set-output name=PR_release_info::{version_info["release-info"]}')
         print(f'::set-output name=PR_includes_release::true')
         make_release_body(version_info["version"],version_info["quay-image"],version_info["release-info"])
-        file.close()
     else:
-        file = open(VERSION_FILE, )
-        version_info = json.load(file)
+        version_info = get_version_info()
         if args.version:
             # should be on main branch
             if semver.compare(args.version,version_info["version"]) > 0 :


### PR DESCRIPTION
Added a worklfow step to add the latest tag a newly created chart verifier release image in quay. 

The image will not have been created when the step starts so the step checks up to 60 times, every 15 seconds for the image to appear. This is a total of 15 minutes. If this fails the image will have to be tagged manually, instructions in the README. The wait time may need adjusting based in it success rate.

Also note to add the tag an OAUTH token is required and is set as a github repository secret "QUAY_AUTH_TOKEN"