### PR TITLE
remove error message output when certifying images

### DIFF
--- a/pkg/chartverifier/checks/helm.go
+++ b/pkg/chartverifier/checks/helm.go
@@ -18,7 +18,6 @@ package checks
 
 import (
 	"bufio"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -209,9 +208,7 @@ func getImageReferences(chartUri string, vals map[string]interface{}) ([]string,
 		Ref string `yaml:"image"`
 	}
 
-	if err != nil {
-		fmt.Printf("RenderManifests error : %v\n", err)
-	} else {
+	if err == nil {
 		r := strings.NewReader(txt)
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {


### PR DESCRIPTION
at the start of some reports you may see two messages, for example:
2021/09/01 17:35:03 [INFO] Missing required value: Git source repository URL is required
RenderManifests error : execution error at (eap74/templates/buildconfig-s2i-build-artifacts.yaml:2:4): Git source repository URL is required

The second message:

RenderManifests error : execution error at .....

messes up loading the report into yaml and causes errors in the workflows. This second message has been removed. 

The first message:

2021/09/01 17:35:03 [INFO] Missing required value: Git source repository URL is required

comes from the helm code and does not seem to cause an issue processing the report