### PR TITLE
add install and test logging

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -153,7 +153,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 					return err
 				}
 
-				cmd.Println(fmt.Sprintf("%s", string(b)))
+				cmd.Println(string(b))
 
 			} else {
 				b, err := yaml.Marshal(result)
@@ -164,10 +164,10 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 				if outputLogs {
 					logs, err := tool.GetLogsOutput(outputFormatFlag)
-					if len(logs) > 0 {
-						cmd.Println(logs)
-					} else {
+					if err != nil {
 						cmd.Println(fmt.Sprintf("LoggingError: %v", err))
+					} else if len(logs) > 0 {
+						cmd.Println(logs)
 					}
 				}
 			}
@@ -195,7 +195,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&verifyOpts.ValueFiles, "set-values", "f", nil, "specify application and check configuration values in a YAML file or a URL (can specify multiple)")
 	cmd.Flags().StringVarP(&openshiftVersionFlag, "openshift-version", "V", "", "version of OpenShift used in the cluster")
-	cmd.Flags().BoolVarP(&outputLogs, "log-output", "l", false, "output logs after report true/false (default: false) ")
+	cmd.Flags().BoolVarP(&outputLogs, "log-output", "l", false, "output logs after report (default: false) ")
 
 	return cmd
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 
@@ -32,6 +33,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier"
+	"github.com/redhat-certification/chart-verifier/pkg/tool"
 )
 
 func init() {
@@ -52,6 +54,8 @@ var (
 	setOverridesFlag []string
 	// openshiftVersionFlag set the value of `certifiedOpenShiftVersions` in the report
 	openshiftVersionFlag string
+	// output logs flag
+	outputLogs bool
 )
 
 func filterChecks(set profiles.FilteredRegistry, subset []string, setEnabled bool, subsetEnabled bool) (chartverifier.FilteredRegistry, error) {
@@ -149,15 +153,23 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 					return err
 				}
 
-				cmd.Println(string(b))
+				cmd.Println(fmt.Sprintf("%s", string(b)))
 
 			} else {
 				b, err := yaml.Marshal(result)
 				if err != nil {
 					return err
 				}
-
 				cmd.Println(string(b))
+
+				if outputLogs {
+					logs, err := tool.GetLogsOutput(outputFormatFlag)
+					if len(logs) > 0 {
+						cmd.Println(logs)
+					} else {
+						cmd.Println(fmt.Sprintf("LoggingError: %v", err))
+					}
+				}
 			}
 			return nil
 		},
@@ -183,6 +195,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&verifyOpts.ValueFiles, "set-values", "f", nil, "specify application and check configuration values in a YAML file or a URL (can specify multiple)")
 	cmd.Flags().StringVarP(&openshiftVersionFlag, "openshift-version", "V", "", "version of OpenShift used in the cluster")
+	cmd.Flags().BoolVarP(&outputLogs, "log-output", "l", false, "output logs after report true/false (default: false) ")
 
 	return cmd
 }

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -94,6 +94,7 @@ This section provides help on the basic usage of Helm chart checks with the podm
         --kube-context string         name of the kubeconfig context to use
         --kube-token string           bearer token used for authentication
         --kubeconfig string           path to the kubeconfig file
+    -l, --log-output                  output logs after report true/false (default: false) 
     -n, --namespace string            namespace scope for this request
     -V, --openshift-version string    set the value of certifiedOpenShiftVersions in the report
     -o, --output string               the output format: default, json or yaml

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -94,7 +94,7 @@ This section provides help on the basic usage of Helm chart checks with the podm
         --kube-context string         name of the kubeconfig context to use
         --kube-token string           bearer token used for authentication
         --kubeconfig string           path to the kubeconfig file
-    -l, --log-output                  output logs after report true/false (default: false) 
+    -l, --log-output                  output logs after report (default: false) 
     -n, --namespace string            namespace scope for this request
     -V, --openshift-version string    set the value of certifiedOpenShiftVersions in the report
     -o, --output string               the output format: default, json or yaml

--- a/docs/helm-chart-troubleshooting.md
+++ b/docs/helm-chart-troubleshooting.md
@@ -109,7 +109,7 @@ a verifier report must be included in the chart submission.
 
 Run the chart verifier and set log_ouput to true to get additional information:
 ```
-$ podman run -it --rm quay.io/redhat-certification/chart-verifier -l=true verify <chart-uri>
+$ podman run -it --rm quay.io/redhat-certification/chart-verifier -l verify <chart-uri>
 ```
 
 

--- a/docs/helm-chart-troubleshooting.md
+++ b/docs/helm-chart-troubleshooting.md
@@ -107,6 +107,11 @@ values are set using chart-verifier flags when generating a report.
 Also note that if chart-verifier flags are required for the chart-verifier chart-testing check to pass 
 a verifier report must be included in the chart submission.
 
+Run the chart verifier and set log_ouput to true to get additional information:
+```
+$ podman run -it --rm quay.io/redhat-certification/chart-verifier -l=true verify <chart-uri>
+```
+
 
 ## Report related submission failures
 

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -87,6 +87,8 @@ func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
 // phases.
 func ChartTesting(opts *CheckOptions) (Result, error) {
 
+	tool.LogInfo("Start chart install and test check")
+
 	cfg := buildChartTestingConfiguration(opts)
 	procExec := tool.NewProcessExecutor(cfg.Debug)
 	extraArgs := strings.Fields(cfg.HelmExtraArgs)
@@ -95,17 +97,20 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 
 	_, path, err := LoadChartFromURI(opts.URI)
 	if err != nil {
+		tool.LogError("End chart install and test check with LoadChartFromURI error")
 		return NewResult(false, err.Error()), nil
 	}
 
 	chrt, err := chart.NewChart(path)
 	if err != nil {
+		tool.LogError("End chart install and test check with NewChart error")
 		return NewResult(false, err.Error()), nil
 	}
 
 	if cfg.Upgrade {
 		oldChrt, err := getChartPreviousVersion(chrt)
 		if err != nil {
+			tool.LogError("End chart install and test check with getChartPreviousVersion error")
 			return NewResult(
 					false,
 					fmt.Sprintf("skipping upgrade test of '%s' because no previous chart is available", chrt.Yaml().Name)),
@@ -113,29 +118,37 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 		}
 		breakingChangeAllowed, err := util.BreakingChangeAllowed(oldChrt.Yaml().Version, chrt.Yaml().Version)
 		if !breakingChangeAllowed {
+			tool.LogError("End chart install and test check with BreakingChangeAllowed not allowed")
 			return NewResult(
 					false,
 					fmt.Sprintf("Skipping upgrade test of '%s' because breaking changes are not allowed for chart", chrt)),
 				nil
 		} else if err != nil {
+			tool.LogError(fmt.Sprintf("End chart install and test check with BreakingChangeAllowed error: %v", err))
 			return NewResult(false, err.Error()), nil
 		}
 		result := upgradeAndTestChart(cfg, oldChrt, chrt, helm, kubectl)
 
 		if result.Error != nil {
+			tool.LogError(fmt.Sprintf("End chart install and test check with upgradeAndTestChart error: %v", result.Error))
 			return NewResult(false, result.Error.Error()), nil
 		}
 	} else {
 		result := installAndTestChartRelease(cfg, chrt, helm, kubectl, opts.Values)
 		if result.Error != nil {
+			tool.LogError(fmt.Sprintf("End chart install and test check with installAndTestChartRelease error: %v", result.Error))
 			return NewResult(false, result.Error.Error()), nil
 		}
 	}
 
 	if versionError := setOCVersion(opts.AnnotationHolder, getVersion); versionError != nil {
+		if versionError != nil {
+			tool.LogWarning(fmt.Sprintf("End chart install and test check with version error: %v", versionError))
+		}
 		return NewResult(false, versionError.Error()), nil
 	}
 
+	tool.LogInfo("End chart install and test check")
 	return NewResult(true, ChartTestingSuccess), nil
 }
 
@@ -242,6 +255,7 @@ func upgradeAndTestChart(
 			result.Error = err
 			break
 		}
+
 	}
 
 	return result

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -46,20 +46,38 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 		values = []interface{}{"--values", valuesFile}
 	}
 
+	LogInfo(fmt.Sprintf("Execute helm install. namespace: %s, release: %s chart: %s", namespace, release, chart))
 	helmArgs := []interface{}{"install", release, chart, "--namespace", namespace, "--wait"}
 	helmArgs = append(helmArgs, values...)
 	helmArgs = append(helmArgs, toInterfaceArray(h.extraArgs)...)
 
 	_, err := h.RunProcessAndCaptureOutput("helm", helmArgs...)
+	if err != nil {
+		LogError(fmt.Sprintf("Execute helm install. error %v", err))
+	} else {
+		LogInfo("Helm install complete")
+	}
+
 	return err
 }
 
 func (h Helm) Test(namespace string, release string) error {
+	LogInfo(fmt.Sprintf("Execute helm test. namespace: %s, release: %s, extraArgd: %v", namespace, release, h.extraArgs))
 	_, err := h.RunProcessAndCaptureOutput("helm", "test", release, "--namespace", namespace, h.extraArgs)
+	if err != nil {
+		LogError(fmt.Sprintf("Execute helm test. error %v", err))
+	} else {
+		LogInfo("Helm test complete")
+	}
 	return err
 }
 
 func (h Helm) DeleteRelease(namespace string, release string) {
-	_, _ = h.RunProcessAndCaptureOutput("helm", "uninstall", release, "--namespace", namespace, h.extraArgs)
-
+	LogInfo(fmt.Sprintf("Execute helm uninstall. namespace: %s, release: %s", namespace, release))
+	_, err := h.RunProcessAndCaptureOutput("helm", "uninstall", release, "--namespace", namespace, h.extraArgs)
+	if err != nil {
+		LogError(fmt.Sprintf("Error from helm uninstall : %v", err))
+	} else {
+		LogInfo("Delete release complete")
+	}
 }

--- a/pkg/tool/test_log.go
+++ b/pkg/tool/test_log.go
@@ -1,0 +1,57 @@
+package tool
+
+import (
+	"encoding/json"
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
+
+type TestLog struct {
+	Name    string      `json:"name" yaml:"name"`
+	Entries []*LogEntry `json:"log" yaml:"log"`
+}
+
+type LogEntry struct {
+	Entry string `json:"Entry" yaml:"Entry"`
+}
+
+var testlog TestLog
+
+func init() {
+	testlog = TestLog{Name: "Chart Verifier Log"}
+}
+
+func LogWarning(message string) {
+	warning_log_entry := LogEntry{Entry: fmt.Sprintf("[WARNING] %s", message)}
+	testlog.Entries = append(testlog.Entries, &warning_log_entry)
+}
+
+func LogInfo(message string) {
+	info_log_entry := LogEntry{Entry: fmt.Sprintf("[INFO] %s", message)}
+	testlog.Entries = append(testlog.Entries, &info_log_entry)
+}
+
+func LogError(message string) {
+	error_log_entry := LogEntry{Entry: fmt.Sprintf("[ERROR} %s", message)}
+	testlog.Entries = append(testlog.Entries, &error_log_entry)
+}
+func GetLogsOutput(log_format string) (string, error) {
+
+	if len(testlog.Entries) > 0 {
+		if log_format == "json" {
+			b, err := json.Marshal(&testlog)
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		} else {
+			b, err := yaml.Marshal(&testlog)
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		}
+	}
+	return "", nil
+
+}

--- a/scripts/src/buildandtest/buildandtest.py
+++ b/scripts/src/buildandtest/buildandtest.py
@@ -47,7 +47,7 @@ def build_image(image_id):
 
 def test_image(image_id,chart,verifier_version):
 
-    docker_command = "verify -l" + chart["url"]
+    docker_command = "verify -l " + chart["url"]
 
     set_values = ""
     vendor_type = ""

--- a/scripts/src/buildandtest/buildandtest.py
+++ b/scripts/src/buildandtest/buildandtest.py
@@ -47,7 +47,7 @@ def build_image(image_id):
 
 def test_image(image_id,chart,verifier_version):
 
-    docker_command = "verify " + chart["url"]
+    docker_command = "verify -l=true" + chart["url"]
 
     set_values = ""
     vendor_type = ""

--- a/scripts/src/buildandtest/buildandtest.py
+++ b/scripts/src/buildandtest/buildandtest.py
@@ -47,7 +47,7 @@ def build_image(image_id):
 
 def test_image(image_id,chart,verifier_version):
 
-    docker_command = "verify -l=true" + chart["url"]
+    docker_command = "verify -l" + chart["url"]
 
     set_values = ""
     vendor_type = ""


### PR DESCRIPTION
Adds flag to enable log output:
```
    -l, --log-output                  output logs after report true/false (default: false) 
```

Log is output in yaml format after the report, to prevent breaking report analysis:

```
name: Chart Verifier Log
log:
  - Entry: '[INFO] Start chart install and test check'
  - Entry: '[INFO] Execute helm install. namespace: default, release: chart-fwo43he8pb
        chart: /Users/martinmulholland/Library/Caches/chart-verifier/pkg_chartverifier_checks_chart_0_1_0_v3_valid_tgz/chart'
  - Entry: |-
        [ERROR} Execute helm install. error Error running process: executing helm with args "install chart-fwo43he8pb /Users/martinmulholland/Library/Caches/chart-verifier/pkg_chartverifier_checks_chart_0_1_0_v3_valid_tgz/chart --namespace default --wait --values /var/folders/19/zzj4wrnj1_g1wdtt_zn61_tm0000gn/T/chart-testing-504248880/values.yaml": exit status 1
        ---
        Error: INSTALLATION FAILED: chart requires kubeVersion: 1.20.0 which is incompatible with Kubernetes v1.22.2
  - Entry: '[INFO] Execute helm uninstall. namespace: default, release: chart-fwo43he8pb'
  - Entry: |-
        [ERROR} Error from helm uninstall : Error running process: executing helm with args "uninstall chart-fwo43he8pb --namespace default []": exit status 1
        ---
        Error: uninstall: Release not loaded: chart-fwo43he8pb: release: not found
  - Entry: |-
        [ERROR} End chart install and test check with installAndTestChartRelease error: Error running process: executing helm with args "install chart-fwo43he8pb /Users/martinmulholland/Library/Caches/chart-verifier/pkg_chartverifier_checks_chart_0_1_0_v3_valid_tgz/chart --namespace default --wait --values /var/folders/19/zzj4wrnj1_g1wdtt_zn61_tm0000gn/T/chart-testing-504248880/values.yaml": exit status 1
        ---
        Error: INSTALLATION FAILED: chart requires kubeVersion: 1.20.0 which is incompatible with Kubernetes v1.22.2
```


Currently only logging is for chart testing