### PR TITLE
(Dockerfile) Add link to chart-verifier so it is on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ COPY ./config /app/config
 
 COPY cmd/release /app/releases
 
+RUN ln -s /app/chart-verifier /usr/local/bin/chart-verifier
+
 ENTRYPOINT ["/app/chart-verifier"]


### PR DESCRIPTION
Signed-off-by: Tim Etchells <tetchel@gmail.com>

This fixes https://github.com/redhat-certification/chart-verifier/issues/205

```
[ /tim/src/chart-verifier ] 52 (main) $ docker run -it --entrypoint=/bin/sh 18a42a011a52
sh-4.4# ls
app  boot  etc	 lib	lost+found  mnt  proc  run   srv  tmp  var
bin  dev   home  lib64	media	    opt  root  sbin  sys  usr
sh-4.4# chart-verifier
Certifies a Helm chart by checking some of its characteristics

Usage:
  chart-verifier [command]

Available Commands:
  help        Help about any command
  report      Provides information from a report
  verify      Verifies a Helm chart by checking some of its characteristics

Flags:
      --config string   config file (default is $HOME/.chart-verifier.yaml)
  -h, --help            help for chart-verifier

Use "chart-verifier [command] --help" for more information about a command.
sh-4.4# exit
```