### PR TITLE
remove redundant digest metadata

### DIFF
--- a/cmd/test/report.yaml
+++ b/cmd/test/report.yaml
@@ -7,7 +7,6 @@ metadata:
             VendorType: redhat
             version: v1.1
         chart-uri: pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz
-        digest: sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0
         digests:
             chart: sha256:0c1c44def5c5de45212d90396062e18e0311b07789f477268fbf233c1783dbd0
             package: 4f29f2a95bf2b9a1c62fd215b079a01bdc5a38e9b4ff874d0fa21d0afca2e76d

--- a/pkg/chartverifier/report.go
+++ b/pkg/chartverifier/report.go
@@ -50,7 +50,6 @@ type ToolMetadata struct {
 	Version                    string  `json:"verifier-version" yaml:"verifier-version"`
 	Profile                    Profile `json:"profile" yaml:"profile"`
 	ChartUri                   string  `json:"chart-uri" yaml:"chart-uri"`
-	Digest                     string  `json:"digest" yaml:"digest"`
 	Digests                    Digests `json:"digests" yaml:"digests"`
 	LastCertifiedTimestamp     string  `json:"lastCertifiedTimestamp,omitempty" yaml:"lastCertifiedTimestamp,omitempty"`
 	CertifiedOpenShiftVersions string  `json:"certifiedOpenShiftVersions,omitempty" yaml:"certifiedOpenShiftVersions,omitempty"`

--- a/pkg/chartverifier/reportBuilder.go
+++ b/pkg/chartverifier/reportBuilder.go
@@ -101,7 +101,6 @@ func (r *reportBuilder) Build() (*Report, error) {
 		switch annotation {
 		case profiles.DigestAnnotation:
 			r.Report.Metadata.ToolMetadata.Digests.Chart = GenerateSha(r.Chart.Raw)
-			r.Report.Metadata.ToolMetadata.Digest = r.Report.Metadata.ToolMetadata.Digests.Chart
 		case profiles.LastCertifiedTimestampAnnotation:
 			r.Report.Metadata.ToolMetadata.LastCertifiedTimestamp = time.Now().Format("2006-01-02T15:04:05.999999-07:00")
 		case profiles.OCPVersionAnnotation:


### PR DESCRIPTION
Remove redundant digest from metadata - was left for compatibility reasons and no longer needed.

See: https://github.com/redhat-certification/chart-verifier/pull/163 
