### PR TITLE
Allow html to be present in release info data

### DIFF
--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -62,7 +62,10 @@ def make_release_body(version, image_name, release_info):
     body = f"Chart verifier version {version} <br><br>Docker Image:<br>- {image_name}:{version}<br><br>"
     body += "This version includes:<br>"
     for info in release_info:
-        body += f"- {info}<br>"
+        if info.startswith("<"):
+            body += info
+        else:
+            body += f"- {info}<br>"
 
     print(f"[INFO] Release body: {body}")
     print(f"::set-output name=PR_release_body::{body}")


### PR DESCRIPTION
The current code enables a simple list of release content but for 1.40 we need something better:

This version includes:

- Profile Version 1.1 introduced (now default):
   - New mandatory check: required-annotations-present/v1.0 (redhat-certification#203).
     - Requires chart annotation charts.openshift.io/name to bet set.
  - Updated mandatory check: has-kubeversion/v1.1 (redhat-certification#213).
    - Requires chart kubeVersion to be a valid semantic version.
    - Adds new supportedOpenShiftVersions attribute used for chart certification.

This change allows for the release_info to be written as html to enable this:

```

    "version": "1.4.0",
    "quay-image":  "quay.io/redhat-certification/chart-verifier",
    "release-info": [
        "<ul><li>Profile Version 1.1 introduced (now default):</li>",
        "<ul><li>New mandatory check: required-annotations-present/v1.0 (#203).</li>",
        "<li>Requires chart annotation charts.openshift.io/name to bet set.</li>",
        "</ul>",
        "<li>Updated mandatory check: has-kubeversion/v1.1 (#213).</li>",
        "<ul><li>Requires chart kubeVersion to be a valid semantic version.</li>",
        "<li>Adds new supportedOpenShiftVersions attribute used for chart certification.</li>",
        "</ul>",
        "</ul>"
    ]
}
```