### PR TITLE
add option for user to specify helm release for testing

### DIFF
--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -248,6 +248,7 @@ You can configure the chart-testing check by performing one of the following ste
         --set chart-testing.skipMissingValues=true                    \
         --set chart-testing.namespace=${NAMESPACE}                    \
         --set chart-testing.releaseLabel="app.kubernetes.io/instance" \
+        --set chart-testing.release=${RELEASE}
         some-chart.tgz
     ```
 * Option 2: Create a YAML file (config.yaml) similar to the following example:
@@ -258,12 +259,15 @@ You can configure the chart-testing check by performing one of the following ste
         skipMissingValues: true
         namespace: <NAMESPACE>
         releaseLabel: "app.kubernetes.io/instance"
+        release: <RELEASE>
     ```
 
     Specify the file using the `--set-values` command line option:
     ```text
     $ chart-verifier verify --enable chart-testing --set-values config.yaml some-chart.tgz
     ```
+
+    All settings are optional, if not set a default values will be used.
 
 ### Override values
 

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -267,7 +267,7 @@ You can configure the chart-testing check by performing one of the following ste
     $ chart-verifier verify --enable chart-testing --set-values config.yaml some-chart.tgz
     ```
 
-    All settings are optional, if not set a default values will be used.
+    All settings are optional, if not set default values will be used.
 
 ### Override values
 

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -16,6 +16,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	ReleaseConfigString string = "release"
+)
+
 // Versioner provides OpenShift version
 type Versioner func() (string, error)
 
@@ -107,6 +111,11 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 		return NewResult(false, err.Error()), nil
 	}
 
+	configRelease := opts.ViperConfig.GetString(ReleaseConfigString)
+	if len(configRelease) >0 {
+		tool.LogInfo(fmt.Sprintf("User specifed release: %s", configRelease))
+	}
+
 	if cfg.Upgrade {
 		oldChrt, err := getChartPreviousVersion(chrt)
 		if err != nil {
@@ -127,14 +136,14 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 			tool.LogError(fmt.Sprintf("End chart install and test check with BreakingChangeAllowed error: %v", err))
 			return NewResult(false, err.Error()), nil
 		}
-		result := upgradeAndTestChart(cfg, oldChrt, chrt, helm, kubectl)
+		result := upgradeAndTestChart(cfg, oldChrt, chrt, helm, kubectl, configRelease)
 
 		if result.Error != nil {
 			tool.LogError(fmt.Sprintf("End chart install and test check with upgradeAndTestChart error: %v", result.Error))
 			return NewResult(false, result.Error.Error()), nil
 		}
 	} else {
-		result := installAndTestChartRelease(cfg, chrt, helm, kubectl, opts.Values)
+		result := installAndTestChartRelease(cfg, chrt, helm, kubectl, opts.Values, configRelease)
 		if result.Error != nil {
 			tool.LogError(fmt.Sprintf("End chart install and test check with installAndTestChartRelease error: %v", result.Error))
 			return NewResult(false, result.Error.Error()), nil
@@ -160,16 +169,24 @@ func generateInstallConfig(
 	chrt *chart.Chart,
 	helm tool.Helm,
 	kubectl tool.Kubectl,
+	configRelease string,
 ) (namespace, release, releaseSelector string, cleanup func()) {
+	release = configRelease
 	if cfg.Namespace != "" {
 		namespace = cfg.Namespace
-		release, _ = chrt.CreateInstallParams(cfg.BuildId)
+		if len(release) == 0 {
+			release, _ = chrt.CreateInstallParams(cfg.BuildId)
+		}
 		releaseSelector = fmt.Sprintf("%s=%s", cfg.ReleaseLabel, release)
 		cleanup = func() {
 			helm.DeleteRelease(namespace, release)
 		}
 	} else {
-		release, namespace = chrt.CreateInstallParams(cfg.BuildId)
+		if len(release) == 0 {
+			release, namespace = chrt.CreateInstallParams(cfg.BuildId)
+		} else {
+			_, namespace = chrt.CreateInstallParams(cfg.BuildId)
+		}
 		cleanup = func() {
 			helm.DeleteRelease(namespace, release)
 			kubectl.DeleteNamespace(namespace)
@@ -209,6 +226,7 @@ func upgradeAndTestChart(
 	oldChrt, chrt *chart.Chart,
 	helm tool.Helm,
 	kubectl tool.Kubectl,
+	configRelease string,
 ) chart.TestResult {
 
 	// result contains the test result; please notice that each values
@@ -233,7 +251,7 @@ func upgradeAndTestChart(
 		// Use anonymous function. Otherwise deferred calls would pile up
 		// and be executed in reverse order after the loop.
 		fun := func() error {
-			namespace, release, releaseSelector, cleanup := generateInstallConfig(cfg, oldChrt, helm, kubectl)
+			namespace, release, releaseSelector, cleanup := generateInstallConfig(cfg, oldChrt, helm, kubectl, configRelease)
 			defer cleanup()
 
 			// Install previous version of chart. If installation fails, ignore this release.
@@ -345,6 +363,7 @@ func installAndTestChartRelease(
 	helm tool.Helm,
 	kubectl tool.Kubectl,
 	valuesOverrides map[string]interface{},
+	configRelease string,
 ) chart.TestResult {
 
 	// valuesFiles contains all the configurations that should be
@@ -373,7 +392,7 @@ func installAndTestChartRelease(
 			}
 			defer tmpValuesFileCleanup()
 
-			namespace, release, releaseSelector, releaseCleanup := generateInstallConfig(cfg, chrt, helm, kubectl)
+			namespace, release, releaseSelector, releaseCleanup := generateInstallConfig(cfg, chrt, helm, kubectl, configRelease)
 			defer releaseCleanup()
 
 			if err := helm.InstallWithValues(chrt.Path(), tmpValuesFile, namespace, release); err != nil {

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -112,7 +112,7 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 	}
 
 	configRelease := opts.ViperConfig.GetString(ReleaseConfigString)
-	if len(configRelease) >0 {
+	if len(configRelease) > 0 {
 		tool.LogInfo(fmt.Sprintf("User specifed release: %s", configRelease))
 	}
 


### PR DESCRIPTION
Adds ability for a chart-verifer user to specify the release to run chart testing on:

```--set chart-testing.release=use-this-1```

this method of setting options for specific tests is used throughout. ie: ```<check-name>.<option-name>``` 

There are requirements on the value used for a release and if you get it wrong install fails, for example:
```
 Error: INSTALLATION FAILED: Service "funny.bone-chart" is invalid: metadata.name: Invalid value: "funny.bone-chart": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

As a result I did not add any checking of a specified  release name when I read it.