### PR TITLE
Fix podman error and add tests

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -25,7 +25,7 @@ jobs:
               uses: actions/setup-go@v2
               with:
                 go-version: '1.17.2'
-
+                
             - name: Check go mod status
               working-directory: ./chart-verifier
               run: |
@@ -117,6 +117,19 @@ jobs:
                   commit_sha=$(git rev-parse --short HEAD)
                   ve1/bin/build-and-test --image-name="quay.io/redhat-certification/chart-verifier" --sha-value=$commit_sha --build-only="True"}
 
+
+            - name: Build podman Image
+              working-directory: ./chart-verifier
+              id: build_podman_image
+              run: |
+                  # build a podman image
+                  # sudo apt install qemu-system-x86
+                  commit_sha=$(git rev-parse --short HEAD)
+                  image_tag="podman-"$commit_sha
+                  echo "use image tag $image_tag"
+                  podman build -t quay.io/redhat-certification/chart-verifier:$image_tag .
+                  echo "::set-output name=podman_image_tag::$image_tag"
+
             - name: Login to oc
               working-directory: ./chart-verifier
               env:
@@ -139,6 +152,7 @@ jobs:
                   KUBECONFIG: /tmp/ci-kubeconfig
                   VERIFIER_IMAGE_TAG:  ${{ steps.build_image.outputs.verifier-image-tag }}
                   VERIFIER_TARBALL_NAME : ${{ steps.check_version_in_PR.outputs.PR_tarball_name }}
+                  PODMAN_IMAGE_TAG : ${{ steps.build_podman_image.outputs.podman_image_tag }}
               id: run_tetst
               run: |
                   # run pytest

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,7 @@ type Release struct {
 func init() {
 
 	var configDir string
-	if isRunningInDockerContainer() {
+	if profiles.IsRunningInContainer() {
 		configDir = filepath.Join("/app", "releases")
 	} else {
 		_, fn, _, ok := runtime.Caller(0)
@@ -58,17 +59,6 @@ func init() {
 
 	Version = release.Version
 	rootCmd.AddCommand(newVersionCmd())
-}
-
-func isRunningInDockerContainer() bool {
-	// docker creates a .dockerenv file at the root
-	// of the directory tree inside the container.
-	// if this file exists then verifier is running
-	// from inside a container
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-	return false
 }
 
 func newVersionCmd() *cobra.Command {

--- a/pkg/chartverifier/profiles/profile.go
+++ b/pkg/chartverifier/profiles/profile.go
@@ -119,7 +119,7 @@ func New(config *viper.Viper) *Profile {
 func getProfiles() {
 
 	var configDir string
-	if isRunningInDockerContainer() {
+	if IsRunningInContainer() {
 		configDir = filepath.Join("/app", "config")
 	} else {
 		_, fn, _, ok := runtime.Caller(0)
@@ -193,12 +193,14 @@ func readProfile(fileName string) (*Profile, error) {
 
 }
 
-func isRunningInDockerContainer() bool {
+func IsRunningInContainer() bool {
 	// docker creates a .dockerenv file at the root
-	// of the directory tree inside the container.
-	// if this file exists then verifier is running
-	// from inside a container
+	// podman create a /run/.containerenv file
+	// if either is present wer are running in a container
 	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+
+	} else if _, err := os.Stat("/run/.containerenv"); err == nil {
 		return true
 	}
 	return false

--- a/tests/tests/functional/features/chart_good.feature
+++ b/tests/tests/functional/features/chart_good.feature
@@ -6,6 +6,7 @@ Feature: Chart  verification
         | image_type |
         | docker |
         | tarball |
+        | podman |
 
     Scenario Outline: A chart provider verifies their chart using the chart verifier
         Given I would like to use the <type> profile


### PR DESCRIPTION
Fixed the reported panic error and added tests.

Note: the podman tests will fail in this build because it is using the old build.yml file which does not build the podman image. As a result the test uses the main image from quay which is not fixed. 

This PR on my branch is using the updated build.yml and  shows the tests passing: https://github.com/mmulholla/chart-verifier/pull/123 