### PR TITLE
Make sure errors are written to stderr

### DIFF
--- a/pkg/chartverifier/utils/logger.go
+++ b/pkg/chartverifier/utils/logger.go
@@ -28,6 +28,7 @@ type LogEntry struct {
 }
 
 var CmdStdout io.Writer = os.Stdout
+var CmdStderr io.Writer = os.Stderr
 
 var verifierlog VerifierLog
 var cmd *cobra.Command
@@ -39,6 +40,7 @@ const outputDirectory string = "chartverifier"
 func InitLog(cobraCmd *cobra.Command, stdFilename string, suppressErrorLog bool) {
 	cmd = cobraCmd
 	stdoutFileName = stdFilename
+	cmd.SetErr(CmdStderr)
 	now := time.Now()
 	verifierlog = VerifierLog{Name: "Chart Verifier Log", Time: now.Format("01-02-2006-15-04-05")}
 	if suppressErrorLog {

--- a/pkg/chartverifier/utils/logger_test.go
+++ b/pkg/chartverifier/utils/logger_test.go
@@ -57,7 +57,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 		tCmd.SetArgs([]string{"LogInfoOnly", "This should not be output"})
 		tCmd.Execute()
 
@@ -71,7 +71,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 
 		output := "This should be output in a log file"
 		tCmd.SetArgs([]string{"LogInfoFile", output})
@@ -93,7 +93,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 		output := "This should be output to file only"
 		tCmd.SetArgs([]string{"StdOutFile", output})
 		tCmd.Execute()
@@ -113,7 +113,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 		output := "This error should be output to stderr and log file"
 		tCmd.SetArgs([]string{"ErrorAndLog", output})
 		tCmd.Execute()
@@ -133,7 +133,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 		output := "This warning should be output to stderr and log file."
 		tCmd.SetArgs([]string{"WarningAndLog", output})
 		tCmd.Execute()
@@ -153,7 +153,7 @@ func TestLogging(t *testing.T) {
 		outBuf := bytes.NewBufferString("")
 		CmdStdout = outBuf
 		errBuf := bytes.NewBufferString("")
-		tCmd.SetErr(errBuf)
+		CmdStderr = errBuf
 
 		tCmd.SetArgs([]string{"testPrune"})
 		for i := 1; i <= 15; i++ {


### PR DESCRIPTION
Some errors were being sent to stdout=. The fix ensures they go to stderr.