### PR TITLE
add 30 minute timeout for helm test

### DIFF
--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -416,9 +417,12 @@ func installAndTestChartRelease(
 			defer releaseCleanup()
 
 			if err := helm.Install(namespace, chrt.Path(), release, tmpValuesFile); err != nil {
-				return err
+				return errors.New(fmt.Sprintf("Chart Install failure: %v", err))
 			}
-			return testRelease(helm, kubectl, release, namespace, releaseSelector, false)
+			if err = testRelease(helm, kubectl, release, namespace, releaseSelector, false); err != nil {
+				return errors.New(fmt.Sprintf("Chart test failure: %v", err))
+			}
+			return nil
 		}
 
 		if err := fun(); err != nil {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -102,8 +102,9 @@ func (h Helm) Test(namespace, release string) error {
 	utils.LogInfo(fmt.Sprintf("Execute helm test. namespace: %s, release: %s, args: %+v", namespace, release, h.args))
 	client := action.NewReleaseTesting(h.config)
 	client.Namespace = namespace
+	client.Timeout = 30 * time.Minute
 
-	// TODO: support filter and timeout options if required
+	// TODO: support filter
 	_, err := client.Run(release)
 	if err != nil {
 		utils.LogError(fmt.Sprintf("Execute helm test. error %v", err))


### PR DESCRIPTION
Prevent hangs if tests take too long - set timeout to 30 minutes to leave plenty of time.
Also improved chart install and testing check reason to include if the failure was in install or test.
for example:
```
- check: v1.0/chart-testing
  type: Mandatory
  outcome: FAIL
  reason: 'Chart Install failure: timed out waiting for the condition'
```