### PR TITLE
create dev release after merge

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -1,0 +1,66 @@
+name: Create dev release
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    build:
+        name: Create Dev Release
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Setup Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: '1.17.2'
+
+            - name: Set up Python 3.x
+              uses: actions/setup-python@v2
+              with:
+                  python-version: '3.9'
+
+            - name: Set up Python scripts
+              run: |
+                # set up python requirements and scripts on PR branch
+                python3 -m venv ve1
+                cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
+                cd scripts && ../ve1/bin/python3 setup.py install && cd ..
+
+            - name: Build Binary
+              id: build-binary
+              run: make bin
+
+            - name: Create tarfile
+              if: ${{ steps.build-binary.outcome == 'success' }}
+              id: create-tarfile
+              run: |
+                # check if release file only is included in PR
+                ve1/bin/tar-file --release="dev"
+
+            - name: Delete previous release and tag
+              if: ${{ steps.create-tarfile.outcome == 'success' }}
+              uses: dev-drprasad/delete-tag-and-release@v0.2.0
+              with:
+                delete_release: true # default: false
+                tag_name: dev # tag name to delete
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create the the release
+              id: create_release
+              if: ${{ always() && steps.create-tarfile.outcome == 'success' }}
+              uses: softprops/action-gh-release@v1
+              with:
+                tag_name: dev
+                body: "Development release created with each merge into the main branch."
+                files: ${{ steps.create-tarfile.outputs.tarball_full_name }}
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -41,3 +41,4 @@ console_scripts =
     check-user = owners.checkuser:main
     link-images = quay.linkimages:main
     sa-for-chart-testing = saforcharttesting.saforcharttesting:main
+    tar-file = release.tarfile_asset:main

--- a/scripts/src/release/tarfile_asset.py
+++ b/scripts/src/release/tarfile_asset.py
@@ -1,5 +1,6 @@
-import tarfile
+import argparse
 import os
+import tarfile
 
 
 tar_content_files = [ {"name": "out/chart-verifier", "arc_name": "chart-verifier"} ]
@@ -8,6 +9,7 @@ tar_content_files = [ {"name": "out/chart-verifier", "arc_name": "chart-verifier
 def create(release):
 
     tgz_name = f"chart-verifier-{release}.tgz"
+    print(f'::set-output name=tarball_base_name::{tgz_name}')
 
     if os.path.exists(tgz_name):
         os.remove(tgz_name)
@@ -18,4 +20,14 @@ def create(release):
 
 
     return os.path.join(os.getcwd(),tgz_name)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--release", dest="release", type=str, required=True,
+                        help="Release name for the tar file")
+
+    args = parser.parse_args()
+    tarfile = create(args.release)
+    print(f'[INFO] Verifier tarball created : {tarfile}.')
+    print(f'::set-output name=tarball_full_name::{tarfile}')
 


### PR DESCRIPTION
Creates a new dev release each time a PR is merged into the main branch. The release includes a binary which can be consumed by the chart verifier github action.

Notes: 
- regular PR's are not auto-merged so creating the release could not be part of the regular workflow.
- i could add a slack message each rime a release is created if needed.
- the first dev release will be created when this PR is merged - causes the new action to run.