### PR TITLE
Add timeout option in the verify cmd

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -19,10 +19,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/utils"
-	"time"
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -135,6 +136,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 			utils.LogInfo(fmt.Sprintf("Chart Verifer %s.", Version))
 			utils.LogInfo(fmt.Sprintf("Verify : %s", args[0]))
+			utils.LogInfo(fmt.Sprintf("Client timeout: %s", clientTimeout))
 
 			// vals is a resulting map considering all the options the user has given.
 			vals, err := opts.MergeValues(getter.All(settings))
@@ -159,6 +161,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 				SetToolVersion(Version).
 				SetOpenShiftVersion(openshiftVersionFlag).
 				SetProviderDelivery(providerDelivery).
+				SetTimeout(clientTimeout).
 				Build()
 
 			if err != nil {

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -217,7 +217,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&verifyOpts.ValueFiles, "set-values", "f", nil, "specify application and check configuration values in a YAML file or a URL (can specify multiple)")
 	cmd.Flags().StringVarP(&openshiftVersionFlag, "openshift-version", "V", "", "version of OpenShift used in the cluster")
-	cmd.Flags().DurationVar(&clientTimeout, "timeout", 30*time.Minute, "time to wait for completion of the verification")
+	cmd.Flags().DurationVar(&clientTimeout, "timeout", 30*time.Minute, "time to wait for completion of chart install and test")
 	cmd.Flags().BoolVarP(&reportToFile, "write-to-file", "w", false, "write report to ./chartverifier/report.yaml (default: stdout)")
 	cmd.Flags().BoolVarP(&suppressErrorLog, "suppress-error-log", "E", false, "suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)")
 	cmd.Flags().BoolVarP(&providerDelivery, "provider-delivery", "d", false, "chart provider will provide the chart delivery mechanism (default: false)")

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -22,6 +22,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/utils"
+	"time"
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -60,6 +61,8 @@ var (
 	suppressErrorLog bool
 	// provider controls chart deliver mechanism.
 	providerDelivery bool
+	//client timeout
+	clientTimeout time.Duration
 )
 
 func filterChecks(set profiles.FilteredRegistry, subset []string, setEnabled bool, subsetEnabled bool) (chartverifier.FilteredRegistry, error) {
@@ -211,6 +214,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&verifyOpts.ValueFiles, "set-values", "f", nil, "specify application and check configuration values in a YAML file or a URL (can specify multiple)")
 	cmd.Flags().StringVarP(&openshiftVersionFlag, "openshift-version", "V", "", "version of OpenShift used in the cluster")
+	cmd.Flags().DurationVar(&clientTimeout, "timeout", 30*time.Minute, "time to wait for completion of the verification")
 	cmd.Flags().BoolVarP(&reportToFile, "write-to-file", "w", false, "write report to ./chartverifier/report.yaml (default: stdout)")
 	cmd.Flags().BoolVarP(&suppressErrorLog, "suppress-error-log", "E", false, "suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)")
 	cmd.Flags().BoolVarP(&providerDelivery, "provider-delivery", "d", false, "chart provider will provide the chart delivery mechanism (default: false)")

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -27,7 +27,7 @@ Helm chart checks are a set of checks against which the Red Hat Helm chart-verif
 - The checks are configurable. For example, if a chart requires additional values to be compliant with the checks, configure the values using the available options. The options are similar to those used by the `helm lint` and `helm template` commands.
 - When there are no error messages, the `helm-lint` check passes the verification and is successful. Messages such as `Warning` and `info` do not cause the check to fail.
 - Profiles define the checks needed based on the chart type: partner, redhat or community.
-    - Profiles are versioned. Each new version may include updated checks, new checks, new annotations or chnaged annotations.
+    - Profiles are versioned. Each new version may include updated checks, new checks, new annotations or changed annotations.
 - The generated report is written to stdout but can optionally be written to a file.
 - An error log is created for all verify commands but can be optionally suppressed.
 - You can indicate that a chart is not to be published in the OpenShift catalogue 
@@ -142,6 +142,7 @@ This section provides help on the basic usage of Helm chart checks with the podm
     -s, --set strings                 overrides a configuration, e.g: dummy.ok=false
     -f, --set-values strings          specify application and check configuration values in a YAML file or a URL (can specify multiple)
     -E, --suppress-error-log          suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)
+        --timeout duration            time to wait for completion of chart install and test (default 30m0s)
     -w, --write-to-file               write report to ./chartverifier/report.yaml (default: stdout)
   Global Flags:
         --config string   config file (default is $HOME/.chart-verifier.yaml)
@@ -188,6 +189,21 @@ This section provides help on the basic usage of Helm chart checks with the podm
           verify -F /values/overrides.yaml              \
           <chart-uri>
   ```
+
+### Timeout Option
+
+Increase the timeout value if chart-testing is going to take more time, default value is 30m.
+
+  ```
+  $ podman run --rm -i                                  \
+          -e KUBECONFIG=/.kube/config                   \
+          -v "${HOME}/.kube":/.kube                     \
+          -v $(pwd):/values                             \
+          "quay.io/redhat-certification/chart-verifier" \
+          verify --timeout 40m                          \
+          <chart-uri>
+  ```
+Note: In case chart-testing takes more time, it is advised to submit the report for certification since the certification process will use the default value of 30m. 
 
 ### Saving the report
 

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -106,8 +106,7 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 
 	utils.LogInfo("Start chart install and test check")
 
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()
 
 	cfg := buildChartTestingConfiguration(opts)

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -288,7 +288,7 @@ func upgradeAndTestChart(
 				return fmt.Errorf("Upgrade testing for release '%s' skipped because of previous revision testing error", release)
 			}
 
-			if err := helm.Upgrade(namespace, oldChrt.Path(), release); err != nil {
+			if err := helm.Upgrade(ctx, namespace, oldChrt.Path(), release); err != nil {
 				return err
 			}
 

--- a/pkg/chartverifier/checks/charttesting.go
+++ b/pkg/chartverifier/checks/charttesting.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/helm/chart-testing/v3/pkg/chart"
@@ -108,7 +107,7 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 	utils.LogInfo("Start chart install and test check")
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute) // Timeout Hardcoded for now, will pe passing as parameter
+	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
 	cfg := buildChartTestingConfiguration(opts)

--- a/pkg/chartverifier/checks/registry.go
+++ b/pkg/chartverifier/checks/registry.go
@@ -17,6 +17,8 @@
 package checks
 
 import (
+	"time"
+
 	"github.com/spf13/viper"
 	helmcli "helm.sh/helm/v3/pkg/cli"
 )
@@ -104,6 +106,8 @@ type CheckOptions struct {
 	HelmEnvSettings *helmcli.EnvSettings
 	// AnnotationHolder provides and API to set the OpenShift Version
 	AnnotationHolder AnnotationHolder
+	// client timeout
+	Timeout time.Duration
 }
 
 type CheckFunc func(options *CheckOptions) (Result, error)

--- a/pkg/chartverifier/helmverifier.go
+++ b/pkg/chartverifier/helmverifier.go
@@ -17,6 +17,8 @@
 package chartverifier
 
 import (
+	"time"
+
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/cli"
@@ -32,6 +34,7 @@ type VerifierBuilder interface {
 	SetToolVersion(string) VerifierBuilder
 	SetOpenShiftVersion(string) VerifierBuilder
 	SetProviderDelivery(bool) VerifierBuilder
+	SetTimeout(time.Duration) VerifierBuilder
 	SetSettings(settings *cli.EnvSettings) VerifierBuilder
 	Build() (Verifier, error)
 }

--- a/pkg/chartverifier/verifier.go
+++ b/pkg/chartverifier/verifier.go
@@ -17,6 +17,8 @@
 package chartverifier
 
 import (
+	"time"
+
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 	"github.com/spf13/viper"
@@ -65,6 +67,7 @@ type verifier struct {
 	profile          *profiles.Profile
 	openshiftVersion string
 	providerDelivery bool
+	timeout          time.Duration
 	values           map[string]interface{}
 }
 
@@ -104,6 +107,7 @@ func (c *verifier) Verify(uri string) (*Report, error) {
 			Values:           c.values,
 			ViperConfig:      c.subConfig(string(check.CheckId.Name)),
 			AnnotationHolder: &holder,
+			Timeout:          c.timeout,
 		})
 
 		if checkErr != nil {

--- a/pkg/chartverifier/verifierbuilder.go
+++ b/pkg/chartverifier/verifierbuilder.go
@@ -19,6 +19,7 @@ package chartverifier
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/profiles"
 
@@ -63,6 +64,7 @@ type verifierBuilder struct {
 	openshiftVersion            string
 	suppportedOpenshiftVersions string
 	providerDelivery            bool
+	timeout                     time.Duration
 	values                      map[string]interface{}
 	settings                    *cli.EnvSettings
 }
@@ -117,6 +119,11 @@ func (b *verifierBuilder) SetProviderDelivery(providerDelivery bool) VerifierBui
 	return b
 }
 
+func (b *verifierBuilder) SetTimeout(timeout time.Duration) VerifierBuilder {
+	b.timeout = timeout
+	return b
+}
+
 func (b *verifierBuilder) GetConfig() *viper.Viper {
 	return b.config
 }
@@ -155,6 +162,7 @@ func (b *verifierBuilder) Build() (Verifier, error) {
 		profile:          profile,
 		openshiftVersion: b.openshiftVersion,
 		providerDelivery: b.providerDelivery,
+		timeout:          b.timeout,
 		values:           b.values,
 	}, nil
 }

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -101,9 +101,10 @@ func (h Helm) Install(ctx context.Context, namespace, chart, release, valuesFile
 
 func (h Helm) Test(ctx context.Context, namespace, release string) error {
 	utils.LogInfo(fmt.Sprintf("Execute helm test. namespace: %s, release: %s, args: %+v", namespace, release, h.args))
+	deadline, _ := ctx.Deadline()
 	client := action.NewReleaseTesting(h.config)
 	client.Namespace = namespace
-	client.Timeout = 30 * time.Minute
+	client.Timeout = deadline.Sub(time.Now())
 
 	// TODO: support filter
 	_, err := client.Run(release)

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -2,6 +2,7 @@ package tool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -106,6 +107,9 @@ func (h Helm) Test(ctx context.Context, namespace, release string) error {
 	client.Namespace = namespace
 	client.Timeout = deadline.Sub(time.Now())
 
+	if client.Timeout <= 0 {
+		return errors.New("Helm test error : timeout has expired")
+	}
 	// TODO: support filter
 	_, err := client.Run(release)
 	if err != nil {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -33,7 +34,7 @@ func NewHelm(envSettings *cli.EnvSettings, args map[string]interface{}) (*Helm, 
 	return helm, nil
 }
 
-func (h Helm) Install(namespace, chart, release, valuesFile string) error {
+func (h Helm) Install(ctx context.Context, namespace, chart, release, valuesFile string) error {
 	utils.LogInfo(fmt.Sprintf("Execute helm install. namespace: %s, release: %s chart: %s", namespace, release, chart))
 	client := action.NewInstall(h.config)
 	client.Namespace = namespace
@@ -88,7 +89,7 @@ func (h Helm) Install(namespace, chart, release, valuesFile string) error {
 	}
 
 	// TODO: support other options if required
-	_, err = client.Run(c, vals)
+	_, err = client.RunWithContext(ctx, c, vals)
 	if err != nil {
 		utils.LogError(fmt.Sprintf("Error running chart install: %v", err))
 		return err
@@ -98,7 +99,7 @@ func (h Helm) Install(namespace, chart, release, valuesFile string) error {
 	return nil
 }
 
-func (h Helm) Test(namespace, release string) error {
+func (h Helm) Test(ctx context.Context, namespace, release string) error {
 	utils.LogInfo(fmt.Sprintf("Execute helm test. namespace: %s, release: %s, args: %+v", namespace, release, h.args))
 	client := action.NewReleaseTesting(h.config)
 	client.Namespace = namespace

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -132,7 +132,7 @@ func (h Helm) Uninstall(namespace, release string) error {
 	return nil
 }
 
-func (h Helm) Upgrade(namespace, chart, release string) error {
+func (h Helm) Upgrade(ctx context.Context, namespace, chart, release string) error {
 	utils.LogInfo(fmt.Sprintf("Execute helm upgrade. namespace: %s, release: %s chart: %s", namespace, release, chart))
 	client := action.NewUpgrade(h.config)
 	client.Namespace = namespace
@@ -160,7 +160,7 @@ func (h Helm) Upgrade(namespace, chart, release string) error {
 	}
 
 	// TODO: support other options if required
-	_, err = client.Run(release, c, vals)
+	_, err = client.RunWithContext(ctx, release, c, vals)
 	if err != nil {
 		utils.LogError(fmt.Sprintf("Error running chart upgrade: %v", err))
 		return err

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -108,7 +108,7 @@ func (h Helm) Test(ctx context.Context, namespace, release string) error {
 	client.Timeout = deadline.Sub(time.Now())
 
 	if client.Timeout <= 0 {
-		return errors.New("Helm test error : timeout has expired")
+		return errors.New("Helm test error : timeout has expired, please consider increasing the timeout using the chart-verifier timeout flag")
 	}
 	// TODO: support filter
 	_, err := client.Run(release)

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -1,8 +1,10 @@
 package tool
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/action"
@@ -45,7 +47,11 @@ func TestInstall(t *testing.T) {
 				args:        map[string]interface{}{"set": "k8Project=default"},
 				envSettings: &cli.EnvSettings{},
 			}
-			err := helm.Install("default", tt.chartPath, tt.releaseName, "")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			err := helm.Install(ctx, "default", tt.chartPath, tt.releaseName, "")
 			if err == nil {
 				require.Equal(t, tt.expected, "")
 			} else {
@@ -255,7 +261,10 @@ func TestReleaseTesting(t *testing.T) {
 					t.Error(err)
 				}
 			}
-			err := helm.Test("default", tt.release.Name)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			err := helm.Test(ctx, "default", tt.release.Name)
 			if err == nil {
 				require.Equal(t, tt.expected, "")
 			} else {

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -224,6 +224,7 @@ func TestReleaseTesting(t *testing.T) {
 		chartPath string
 		release   *release.Release
 		expected  string
+		timeout   time.Duration
 	}{
 		{
 			name:      "successful release test should not return error",
@@ -237,6 +238,7 @@ func TestReleaseTesting(t *testing.T) {
 				Hooks:     testHooks,
 			},
 			expected: "",
+			timeout:  10 * time.Second,
 		},
 		{
 			name:      "release test on non-existent release should result in error",
@@ -250,6 +252,7 @@ func TestReleaseTesting(t *testing.T) {
 				Hooks:     testHooks,
 			},
 			expected: "release: not found",
+			timeout:  10 * time.Second,
 		},
 	}
 
@@ -273,10 +276,11 @@ func TestReleaseTesting(t *testing.T) {
 					t.Error(err)
 				}
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
 			defer cancel()
-
+			before_test_time := time.Now()
 			err := helm.Test(ctx, "default", tt.release.Name)
+			require.WithinDuration(t, before_test_time, time.Now(), tt.timeout)
 			if err == nil {
 				require.Equal(t, tt.expected, "")
 			} else {

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -265,7 +265,7 @@ func TestReleaseTesting(t *testing.T) {
 				Namespace: "default",
 				Hooks:     testHooks,
 			},
-			expected: "Helm test error : timeout has expired",
+			expected: "Helm test error : timeout has expired, please consider increasing the timeout using the chart-verifier timeout flag",
 			timeout:  -1 * time.Second,
 		},
 	}

--- a/pkg/tool/helm_test.go
+++ b/pkg/tool/helm_test.go
@@ -181,7 +181,9 @@ func TestUpgrade(t *testing.T) {
 					t.Error(err)
 				}
 			}
-			err := helm.Upgrade("default", tt.chartPath, tt.release.Name)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := helm.Upgrade(ctx, "default", tt.chartPath, tt.release.Name)
 			if err == nil {
 				require.Equal(t, tt.expected, "")
 			} else {


### PR DESCRIPTION
This PR will cover story: https://issues.redhat.com/browse/HELM-324

If the chart contains hooks that takes more time to finish installation and test a release, timeout is implemented (with default value of 30 mins) as total time chart-verifier should wait till the chart install and test finishes.