### PR TITLE
PDC: Require a tarball and omit chart-uri from report

### DIFF
--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -189,7 +189,7 @@ func TestCertify(t *testing.T) {
 
 	})
 
-	t.Run("should see providerControlledDelivery is true for -d flag", func(t *testing.T) {
+	t.Run("should see providerControlledDelivery is true for -d flag and chart-uri is not set", func(t *testing.T) {
 
 		cmd := NewVerifyCmd(viper.New())
 		outBuf := bytes.NewBufferString("")
@@ -211,10 +211,11 @@ func TestCertify(t *testing.T) {
 		err := yaml.Unmarshal([]byte(outBuf.String()), &certificate)
 		require.NoError(t, err)
 		require.True(t, certificate.Metadata.ToolMetadata.ProviderDelivery)
+		require.True(t, certificate.Metadata.ToolMetadata.ChartUri == "N/A")
 
 	})
 
-	t.Run("should see providerControlledDelivery is false if no -d flag", func(t *testing.T) {
+	t.Run("should see providerControlledDelivery is false if no -d flag and chart-uri is set", func(t *testing.T) {
 
 		cmd := NewVerifyCmd(viper.New())
 		outBuf := bytes.NewBufferString("")
@@ -235,6 +236,7 @@ func TestCertify(t *testing.T) {
 		err := yaml.Unmarshal([]byte(outBuf.String()), &certificate)
 		require.NoError(t, err)
 		require.False(t, certificate.Metadata.ToolMetadata.ProviderDelivery)
+		require.True(t, certificate.Metadata.ToolMetadata.ChartUri == "../pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz")
 
 	})
 

--- a/docs/helm-chart-submission.md
+++ b/docs/helm-chart-submission.md
@@ -29,7 +29,13 @@ For troubleshooting report related submission failures see: [Troubleshooting](./
 
 ## Provider controlled delivery
 
-By default, a submitted chart will be made available in the OpenShift Helm Chart Catalog on successful certification. In some cases this is undesirable and can be prevented based on the following conditions:
+By default, a submitted chart will be made available in the OpenShift Helm Chart Catalog on successful certification. In some cases this is undesirable and can be prevented using provider controlled delivery. With provider controlled delivery the provider of the chart controls access to the chart and this impacts report generation:
+
+- The report must be generated using a tarball so that a package digest can be determined and included in the report.
+  - if a tarball is not used the report will fail to generate.
+- The chart URL may be considered private to the provider so the chart URL is not included in the report.
+
+Provider controlled delivery is then based on the following conditions: 
 
 1. When generating the Verification report the ```--provider-delivery``` flag is used.
    Example:

--- a/pkg/chartverifier/reportBuilder.go
+++ b/pkg/chartverifier/reportBuilder.go
@@ -144,6 +144,10 @@ func (r *reportBuilder) Build() (*Report, error) {
 
 	r.Report.Metadata.ToolMetadata.Digests.Package = GetPackageDigest(r.Report.Metadata.ToolMetadata.ChartUri)
 
+	if r.Report.Metadata.ToolMetadata.ProviderDelivery {
+		r.SetChartUri(("N/A"))
+	}
+
 	return &r.Report, nil
 }
 

--- a/pkg/chartverifier/verifier.go
+++ b/pkg/chartverifier/verifier.go
@@ -81,6 +81,12 @@ func (c *verifier) subConfig(name string) *viper.Viper {
 
 func (c *verifier) Verify(uri string) (*Report, error) {
 
+	if c.providerDelivery {
+		if len(GetPackageDigest(uri)) == 0 {
+			return nil, CheckErr("Provider delivery control requires chart input which is a tarball.")
+		}
+	}
+
 	chrt, _, err := checks.LoadChartFromURI(uri)
 	if err != nil {
 		return nil, err

--- a/pkg/chartverifier/verifier_test.go
+++ b/pkg/chartverifier/verifier_test.go
@@ -113,11 +113,12 @@ func TestVerifier_Verify(t *testing.T) {
 	t.Run("Result should be positive if check exists and returns positive", func(t *testing.T) {
 		dummyCheck.Func = positiveCheck
 		c := &verifier{
-			settings:       cli.New(),
-			config:         viper.New(),
-			profile:        profiles.Get(),
-			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
-			requiredChecks: []checks.Check{dummyCheck},
+			settings:         cli.New(),
+			config:           viper.New(),
+			profile:          profiles.Get(),
+			registry:         checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
+			requiredChecks:   []checks.Check{dummyCheck},
+			providerDelivery: true,
 		}
 
 		r, err := c.Verify(validChartUri)
@@ -126,5 +127,20 @@ func TestVerifier_Verify(t *testing.T) {
 		require.True(t, r.isOk())
 	})
 
+	t.Run("Result should be negative is provider deliver is set and uri is not a tarball", func(t *testing.T) {
+		dummyCheck.Func = positiveCheck
+		c := &verifier{
+			settings:         cli.New(),
+			config:           viper.New(),
+			profile:          profiles.Get(),
+			registry:         checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
+			requiredChecks:   []checks.Check{dummyCheck},
+			providerDelivery: true,
+		}
+
+		r, err := c.Verify("./checks/psql-service-0.1.7")
+		require.Error(t, err)
+		require.Nil(t, r)
+	})
 	cancel()
 }


### PR DESCRIPTION
Added code for provider control delivery:
- require report is created using a tarball from which a package digest can be calculated.
- set chart-uri in report to "N/A"

Existing tests extended to check both scenarios.
Readme doc updated. 

https://issues.redhat.com/browse/HELM-352