### PR TITLE
allow for pyxis responses spanning more than one page

### DIFF
--- a/pkg/chartverifier/pyxis/pyxis.go
+++ b/pkg/chartverifier/pyxis/pyxis.go
@@ -51,12 +51,8 @@ type RegistriesBody struct {
 
 type PyxisRegistry struct {
 	Id           string               `json:"_id"`
-	ParsedData   ImageData            `json:"parsed_data"`
+	ImageId      string               `json:"image_id"`
 	Repositories []RegistryRepository `json:"repositories"`
-}
-
-type ImageData struct {
-	Digest string `json:"docker_image_digest"`
 }
 
 type RegistryRepository struct {
@@ -190,13 +186,13 @@ Loops:
 						found = false
 						for _, reg := range registriesBody.PyxisRegistries {
 							if len(imageRef.Sha) > 0 {
-								if imageRef.Sha == reg.ParsedData.Digest {
+								if imageRef.Sha == reg.ImageId {
 									utils.LogInfo(fmt.Sprintf("sha found: %s", imageRef.Sha))
 									found = true
 									err = nil
 									continue Loops
 								} else {
-									shas = append(shas, reg.ParsedData.Digest)
+									shas = append(shas, reg.ImageId)
 								}
 							} else {
 								for _, repo := range reg.Repositories {

--- a/pkg/chartverifier/pyxis/pyxis_test.go
+++ b/pkg/chartverifier/pyxis/pyxis_test.go
@@ -35,7 +35,8 @@ func Test_getImageRegistries(t *testing.T) {
 		{description: "Test rhel6.7 respository", repository: "rhel6.7", registry: "registry.access.redhat.com", message: ""},
 		{description: "Test rhel8/nginx-116 respository", repository: "rhel8/nginx-116", registry: "registry.access.redhat.com", message: ""},
 		{description: "Test ibm/nginx respository", repository: "ibm/nginx", registry: "non_registry", message: ""},
-		{description: "Test turbonomic/zookeeper respository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""}}
+		{description: "Test turbonomic/zookeeper respository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""}}
 
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -75,8 +76,8 @@ func Test_checkImageInRegistry(t *testing.T) {
 		{description: "Test turbonomic/zookeeper respository and version found.", imageRef: ImageReference{Repository: "turbonomic/zookeeper", Registries: []string{"registry.connect.redhat.com"}, Tag: "8.1.2", Sha: ""}, message: ""},
 		{description: "Test cpopen/ibmcloud-object-storage-driver respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f"}, message: ""},
 		{description: "Test cpopen/ibmcloud-object-storage-plugin respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}, message: ""},
+		{description: "Test postgresql-10-rhel7 respository and tag found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "latest", Sha: ""}, message: ""},
 	}
-
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {
 			found, err := IsImageInRegistry(tc.imageRef)

--- a/pkg/chartverifier/pyxis/pyxis_test.go
+++ b/pkg/chartverifier/pyxis/pyxis_test.go
@@ -77,6 +77,8 @@ func Test_checkImageInRegistry(t *testing.T) {
 		{description: "Test cpopen/ibmcloud-object-storage-driver respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f"}, message: ""},
 		{description: "Test cpopen/ibmcloud-object-storage-plugin respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}, message: ""},
 		{description: "Test postgresql-10-rhel7 respository and tag found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "latest", Sha: ""}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-plugin respository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:7c00bc76f91d456164f98375cd8932a0ec500c9dca1728368f3c1ccdbfd96e91"}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-driver respository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:667667c5907d0ad145e8518ca0f8cf013ca778d6738b028d1cd08103b1b64667"}, message: ""},
 	}
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Updated code to allow for pyxis returning data in multiple pages. Also added some logging to image certification check. 
For testing added test for ```registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest``` which is only found on the second pyxis page. 

see: https://github.com/redhat-certification/chart-verifier/issues/259
see: https://issues.redhat.com/browse/HELM-361

Added a second commit or a second fix needed by IBM. Basically now get the image sha from  the ```image_id```  attribute instead of ```parsed_data.docker_image_id``` which seemed to disappear. The new attribute was recommended by the Pyxis teaam.
see: https://issues.redhat.com/browse/HELM-362