### PR TITLE
Set dry-run when running helm template

### DIFF
--- a/pkg/helm/actions/template.go
+++ b/pkg/helm/actions/template.go
@@ -19,7 +19,7 @@ func RenderManifests(name string, url string, vals map[string]interface{}, conf 
 	response := make(map[string]string)
 	validate := false
 	client := action.NewInstall(conf)
-	client.DryRun = false
+	client.DryRun = true
 	includeCrds := true
 	client.ReleaseName = "RELEASE-NAME"
 	client.Replace = true // Skip the releaseName check


### PR DESCRIPTION
Set dry-run when running helm template for the certified images check. This ensure the chart kubeVersion is checked against the install cluster and not the helm client default:

see: https://issues.redhat.com/browse/HELM-370

Note: Existing regression run is sufficient test. 