### PR TITLE
build: update setup-go version selector

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Go
               uses: actions/setup-go@v2
               with:
-                go-version: '1.17.2'
+                go-version: '>=1.17.0'
                 
             - name: Check go mod status
               working-directory: ./chart-verifier


### PR DESCRIPTION
Use the latest patch version of golang 1.17.

Signed-off-by: Igor Sutton <isuttonl@redhat.com>