### PR TITLE
Changes made to use the repository cache in developer console

### DIFF
--- a/internal/chartverifier/api/verifier.go
+++ b/internal/chartverifier/api/verifier.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/spf13/viper"
+	"helm.sh/helm/v3/pkg/cli"
 
 	"time"
 
@@ -29,6 +30,7 @@ type RunOptions struct {
 	SuppressErrorLog bool
 	ClientTimeout    time.Duration
 	ChartUri         string
+	Settings         *cli.EnvSettings
 }
 
 func Run(options RunOptions) (*apireport.Report, error) {
@@ -39,7 +41,8 @@ func Run(options RunOptions) (*apireport.Report, error) {
 
 	verifierBuilder.SetValues(options.Values).
 		SetConfig(options.ViperConfig).
-		SetOverrides(options.Overrides)
+		SetOverrides(options.Overrides).
+		SetSettings(options.Settings)
 
 	profileChecks := profiles.New(options.Overrides).FilterChecks(allChecks)
 
@@ -59,6 +62,7 @@ func Run(options RunOptions) (*apireport.Report, error) {
 		SetOpenShiftVersion(options.OpenShiftVersion).
 		SetProviderDelivery(options.ProviderDelivery).
 		SetTimeout(options.ClientTimeout).
+		SetSettings(options.Settings).
 		Build()
 
 	if err != nil {

--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -123,7 +123,7 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 		return NewResult(false, err.Error()), nil
 	}
 
-	_, path, err := LoadChartFromURI(opts.URI)
+	_, path, err := LoadChartFromURI(opts)
 	if err != nil {
 		utils.LogError("End chart install and test check with LoadChartFromURI error")
 		return NewResult(false, err.Error()), nil

--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -71,7 +71,7 @@ func notImplemented() (Result, error) {
 }
 
 func IsHelmV3(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -85,7 +85,7 @@ func IsHelmV3(opts *CheckOptions) (Result, error) {
 }
 
 func HasReadme(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -101,7 +101,7 @@ func HasReadme(opts *CheckOptions) (Result, error) {
 }
 
 func ContainsTest(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -120,7 +120,7 @@ func ContainsTest(opts *CheckOptions) (Result, error) {
 }
 
 func ContainsValues(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -135,7 +135,7 @@ func ContainsValues(opts *CheckOptions) (Result, error) {
 }
 
 func ContainsValuesSchema(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -162,7 +162,7 @@ func IsCommunityChart(opts *CheckOptions) (Result, error) {
 }
 
 func HasKubeVersion(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
 	}
@@ -177,7 +177,7 @@ func HasKubeVersion(opts *CheckOptions) (Result, error) {
 
 func HasKubeVersion_V1_1(opts *CheckOptions) (Result, error) {
 
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
 	}
@@ -197,7 +197,7 @@ func HasKubeVersion_V1_1(opts *CheckOptions) (Result, error) {
 }
 
 func NotContainCRDs(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
 	}
@@ -213,7 +213,7 @@ func NotContainCRDs(opts *CheckOptions) (Result, error) {
 }
 
 func HelmLint(opts *CheckOptions) (Result, error) {
-	_, p, err := LoadChartFromURI(opts.URI)
+	_, p, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
 	}
@@ -234,7 +234,7 @@ func NotContainsInfraPluginsAndDrivers(opts *CheckOptions) (Result, error) {
 }
 
 func NotContainCSIObjects(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -306,7 +306,7 @@ func ImagesAreCertified(opts *CheckOptions) (Result, error) {
 }
 
 func RequiredAnnotationsPresent(opts *CheckOptions) (Result, error) {
-	c, _, err := LoadChartFromURI(opts.URI)
+	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
 	}

--- a/internal/chartverifier/checks/checks_test.go
+++ b/internal/chartverifier/checks/checks_test.go
@@ -55,8 +55,9 @@ func TestIsHelmV3(t *testing.T) {
 
 	for _, tc := range negativeTestCases {
 		config := viper.New()
+		settings := cli.New()
 		t.Run(tc.description, func(t *testing.T) {
-			r, err := IsHelmV3(&CheckOptions{URI: tc.uri, ViperConfig: config})
+			r, err := IsHelmV3(&CheckOptions{URI: tc.uri, ViperConfig: config, HelmEnvSettings: settings})
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			require.False(t, r.Ok)

--- a/internal/chartverifier/reportbuilder_test.go
+++ b/internal/chartverifier/reportbuilder_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/cli"
 
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/stretchr/testify/require"
@@ -26,7 +28,12 @@ func TestSha(t *testing.T) {
 	// get shas for each file
 	for _, chart := range charts {
 		t.Run("Sha generation : "+chart, func(t *testing.T) {
-			helmChart, _, err := checks.LoadChartFromURI(chart)
+			opts := checks.CheckOptions{
+				URI:             chart,
+				ViperConfig:     viper.New(),
+				HelmEnvSettings: cli.New(),
+			}
+			helmChart, _, err := checks.LoadChartFromURI(&opts)
 			require.NoError(t, err)
 			sha := GenerateSha(helmChart.Raw)
 			require.NotNil(t, sha)
@@ -39,7 +46,12 @@ func TestSha(t *testing.T) {
 		for _, chart := range charts {
 
 			t.Run("Sha must not change : "+chart, func(t *testing.T) {
-				helmChart, _, err := checks.LoadChartFromURI(chart)
+				opts := checks.CheckOptions{
+					URI:             chart,
+					ViperConfig:     viper.New(),
+					HelmEnvSettings: cli.New(),
+				}
+				helmChart, _, err := checks.LoadChartFromURI(&opts)
 				require.NoError(t, err)
 				sha := GenerateSha(helmChart.Raw)
 				require.NotNil(t, sha)

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -17,12 +17,13 @@
 package chartverifier
 
 import (
+	"time"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"github.com/spf13/viper"
 	helmcli "helm.sh/helm/v3/pkg/cli"
-	"time"
 )
 
 type CheckNotFoundErr string
@@ -87,7 +88,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 		}
 	}
 
-	chrt, _, err := checks.LoadChartFromURI(uri)
+	chrt, _, err := checks.LoadChartFromURI(&checks.CheckOptions{HelmEnvSettings: c.settings, URI: uri})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/chartverifier/verifier/verifier.go
+++ b/pkg/chartverifier/verifier/verifier.go
@@ -299,6 +299,7 @@ func (v *Verifier) Run(chart_uri string) (ApiVerifier, error) {
 	settings := cli.New()
 
 	setHelmEnv(settings, v.Inputs.Flags.StringFlags)
+	runOptions.Settings = settings
 
 	if valueMap, ok := v.Inputs.Flags.ValuesFlags[ChartSet]; ok {
 		opts.Values = mapToStringSlice(valueMap)


### PR DESCRIPTION
This PR proposes the changes  made to chart verifier api to use the repository cache to locate the chart instead of creating a directory on console.
Jira:https://issues.redhat.com/browse/HELM-386
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>