### PR TITLE
create and use tarball in build.yaml

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -130,6 +130,14 @@ jobs:
                   podman build -t quay.io/redhat-certification/chart-verifier:$image_tag .
                   echo "::set-output name=podman_image_tag::$image_tag"
 
+            - name: Create tarfile
+              id: create-tarfile
+              working-directory: ./chart-verifier
+              run: |
+                # check if release file only is included in PR
+                ve1/bin/tar-file --release="test"
+
+
             - name: Login to oc
               working-directory: ./chart-verifier
               env:
@@ -151,9 +159,9 @@ jobs:
               env:
                   KUBECONFIG: /tmp/ci-kubeconfig
                   VERIFIER_IMAGE_TAG:  ${{ steps.build_image.outputs.verifier-image-tag }}
-                  VERIFIER_TARBALL_NAME : ${{ steps.check_version_in_PR.outputs.PR_tarball_name }}
+                  VERIFIER_TARBALL_NAME : ${{ steps.create-tarfile.outputs.tarball_full_name }}
                   PODMAN_IMAGE_TAG : ${{ steps.build_podman_image.outputs.podman_image_tag }}
-              id: run_tetst
+              id: run_test
               run: |
                   # run pytest
                   ve1/bin/pytest -v --log-cli-level=WARNING --tb=short


### PR DESCRIPTION
This is needed for the signed chart PR which will follow this.

It creates a new tarball for PR testing which is needed if the PR, is for example, adding a new flag. In the signed chart PR a new pgp-public-key flag is added which is required in the tarball for testing to pass.    

This fix has been tested see: https://github.com/mmulholla/chart-verifier/pull/168