### PR TITLE
add install timeout and deployment wait

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -65,6 +65,8 @@ var (
 	clientTimeout time.Duration
 	// pgp public key file
 	pgpPublicKeyFile string
+	//helm install timeout
+	helmInstallTimeout time.Duration
 )
 
 func buildChecks(enabled []string, unEnabled []string) ([]apiChecks.CheckName, []apiChecks.CheckName, error) {
@@ -163,6 +165,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 			utils.LogInfo(fmt.Sprintf("Chart Verifer %s.", apiversion.GetVersion()))
 			utils.LogInfo(fmt.Sprintf("Verify : %s", args[0]))
 			utils.LogInfo(fmt.Sprintf("Client timeout: %s", clientTimeout))
+			utils.LogInfo(fmt.Sprintf("Helm Install timeout: %s", helmInstallTimeout))
 
 			valueMap := convertToMap(verifyOpts.Values)
 			for key, val := range viper.AllSettings() {
@@ -186,6 +189,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 			verifier, runErr = verifier.SetBoolean(apiverifier.ProviderDelivery, providerDelivery).
 				SetBoolean(apiverifier.SuppressErrorLog, suppressErrorLog).
 				SetDuration(apiverifier.Timeout, clientTimeout).
+				SetDuration(apiverifier.HelmInstallTimeout, helmInstallTimeout).
 				SetString(apiverifier.OpenshiftVersion, []string{openshiftVersionFlag}).
 				SetString(apiverifier.ChartValues, opts.ValueFiles).
 				SetString(apiverifier.KubeApiServer, []string{settings.KubeAPIServer}).
@@ -248,6 +252,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 	cmd.Flags().BoolVarP(&suppressErrorLog, "suppress-error-log", "E", false, "suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)")
 	cmd.Flags().BoolVarP(&providerDelivery, "provider-delivery", "d", false, "chart provider will provide the chart delivery mechanism (default: false)")
 	cmd.Flags().StringVarP(&pgpPublicKeyFile, "pgp-public-key", "k", "", "file containing gpg public key of the key used to sign the chart")
+	cmd.Flags().DurationVar(&helmInstallTimeout, "helm-install-timeout", 5*time.Minute, "helm install timeout")
 	return cmd
 }
 

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -19,6 +19,7 @@ Helm chart checks are a set of checks against which the Red Hat Helm chart-verif
     - [Cluster Config](#cluster-config)
     - [Override values](#override-values)
     - [Check processing](#check-processing)
+    - [Chart testing timeouts](#chart-testing-timeouts)
 - [Signed Charts](#signed-charts)
 
 ## Key features
@@ -129,6 +130,7 @@ This section provides help on the basic usage of Helm chart checks with the podm
         --debug                       enable verbose output
     -x, --disable strings             all checks will be enabled except the informed ones
     -e, --enable strings              only the informed checks will be enabled
+        --helm-install-timeout duration   helm install timeout (default 5m0s)
     -h, --help                        help for verify
         --kube-apiserver string       the address and the port for the Kubernetes API server
         --kube-as-group stringArray   group to impersonate for the operation, this flag can be repeated to specify multiple groups.
@@ -459,6 +461,32 @@ The `chart-testing` check performs the following actions, keeping the semantics 
 1. Test: once a release is installed for the chart being verified, performs the same actions as helm test would, which installing all chart resources containing the "helm.sh/hook": test annotation.
 
 The check will be considered successful when the chart's installation and tests are all successful.
+
+### Chart testing timeouts
+
+For the chart install and test check there are two configurable timeout options:
+
+- ```--helm-install-timeout```
+    - limits how long the `chart-testing` check waits for chart install to complete.
+    - default is 5 minutes
+    - set for example:
+      ```--helm-install-timeout  10m0s```
+- ```--timeout```
+    - limits how long the check waits for the `chart-testing` check to complete: 
+        1. chart install
+        2. wait for deployments to be available
+        3. run the test
+    - default is 30 minutes
+    - set for example:
+        ```--timeout  60m0s```
+      
+Notes: 
+- The timeouts are independent. 
+  - Changing one timeout does not impact the other.
+  - If ```helm-install-timeout``` is increased, consider also increasing ```timeout```
+- The [helm chart certification process](./helm-chart-submission.md#submission-of-helm-charts-for-red-hat-openShift-certification) uses default timeout values.
+  - If a helm chart can only pass the chart testing check with modified timeouts a verifier report must be included in the chart submission.  
+
 
 ## Signed charts
 

--- a/docs/helm-chart-troubleshooting.md
+++ b/docs/helm-chart-troubleshooting.md
@@ -117,6 +117,9 @@ values are set using chart-verifier flags when generating a report.
 Also note that if chart-verifier flags are required for the chart-verifier chart-testing check to pass 
 a verifier report must be included in the chart submission.
 
+If the check fails due to a timeout, increase the timeout values. If increased timeouts are required for the chart-verifier chart-testing check to pass
+a verifier report must be included in the chart submission. See: [Chart testing timeouts](./helm-chart-checks.md#chart-testing-timeouts)
+
 Run the chart verifier and set log_ouput to true to get additional information:
 ```
 $ podman run --rm -i \

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 require (
 	github.com/google/uuid v1.3.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
+	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	k8s.io/helm v2.17.0+incompatible
@@ -146,7 +147,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.24.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/apiserver v0.24.2 // indirect
 	k8s.io/cli-runtime v0.24.2 // indirect

--- a/internal/chartverifier/api/verifier.go
+++ b/internal/chartverifier/api/verifier.go
@@ -20,18 +20,19 @@ func init() {
 }
 
 type RunOptions struct {
-	APIVersion       string
-	Values           map[string]interface{}
-	ViperConfig      *viper.Viper
-	Overrides        map[string]interface{}
-	ChecksToRun      []apichecks.CheckName
-	OpenShiftVersion string
-	ProviderDelivery bool
-	SuppressErrorLog bool
-	ClientTimeout    time.Duration
-	ChartUri         string
-	Settings         *cli.EnvSettings
-	PublicKeys       []string
+	APIVersion         string
+	Values             map[string]interface{}
+	ViperConfig        *viper.Viper
+	Overrides          map[string]interface{}
+	ChecksToRun        []apichecks.CheckName
+	OpenShiftVersion   string
+	ProviderDelivery   bool
+	SuppressErrorLog   bool
+	ClientTimeout      time.Duration
+	HelmInstallTimeout time.Duration
+	ChartUri           string
+	Settings           *cli.EnvSettings
+	PublicKeys         []string
 }
 
 func Run(options RunOptions) (*apireport.Report, error) {
@@ -63,6 +64,7 @@ func Run(options RunOptions) (*apireport.Report, error) {
 		SetOpenShiftVersion(options.OpenShiftVersion).
 		SetProviderDelivery(options.ProviderDelivery).
 		SetTimeout(options.ClientTimeout).
+		SetHelmInstallTimeout(options.HelmInstallTimeout).
 		SetSettings(options.Settings).
 		SetPublicKeys(options.PublicKeys).
 		Build()

--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -110,7 +110,7 @@ func ChartTesting(opts *CheckOptions) (Result, error) {
 	defer cancel()
 
 	cfg := buildChartTestingConfiguration(opts)
-	helm, err := tool.NewHelm(opts.HelmEnvSettings, opts.Values)
+	helm, err := tool.NewHelm(opts.HelmEnvSettings, opts.Values, opts.HelmInstallTimeout)
 	if err != nil {
 		utils.LogError("End chart install and test check with NewHelm error")
 		return NewResult(false, err.Error()), nil

--- a/internal/chartverifier/checks/registry.go
+++ b/internal/chartverifier/checks/registry.go
@@ -106,6 +106,8 @@ type CheckOptions struct {
 	Timeout time.Duration
 	// keyring - public gpg for signed chart
 	PublicKeys []string
+	// helm install timeout
+	HelmInstallTimeout time.Duration
 }
 
 type CheckFunc func(options *CheckOptions) (Result, error)

--- a/internal/chartverifier/helmverifier.go
+++ b/internal/chartverifier/helmverifier.go
@@ -36,6 +36,7 @@ type VerifierBuilder interface {
 	SetProviderDelivery(bool) VerifierBuilder
 	SetTimeout(time.Duration) VerifierBuilder
 	SetPublicKeys([]string) VerifierBuilder
+	SetHelmInstallTimeout(time.Duration) VerifierBuilder
 	SetSettings(settings *cli.EnvSettings) VerifierBuilder
 	Build() (Verifier, error)
 }

--- a/internal/chartverifier/utils/logger.go
+++ b/internal/chartverifier/utils/logger.go
@@ -54,12 +54,12 @@ func LogWarning(message string) {
 	if cmd != nil {
 		cmd.PrintErrln(message)
 	}
-	warning_log_entry := LogEntry{Entry: fmt.Sprintf("[WARNING] %s", message)}
+	warning_log_entry := LogEntry{Entry: fmt.Sprintf("[WARNING] %s : %s", getTimeStamp(), message)}
 	verifierlog.Entries = append(verifierlog.Entries, &warning_log_entry)
 }
 
 func LogInfo(message string) {
-	info_log_entry := LogEntry{Entry: fmt.Sprintf("[INFO] %s", message)}
+	info_log_entry := LogEntry{Entry: fmt.Sprintf("[INFO] %s : %s", getTimeStamp(), message)}
 	verifierlog.Entries = append(verifierlog.Entries, &info_log_entry)
 }
 
@@ -67,7 +67,7 @@ func LogError(message string) {
 	if cmd != nil {
 		cmd.PrintErrln(message)
 	}
-	error_log_entry := LogEntry{Entry: fmt.Sprintf("[ERROR] %s", message)}
+	error_log_entry := LogEntry{Entry: fmt.Sprintf("[ERROR] %s : %s", getTimeStamp(), message)}
 	verifierlog.Entries = append(verifierlog.Entries, &error_log_entry)
 }
 
@@ -221,4 +221,10 @@ func pruneLogFiles() {
 
 	}
 
+}
+
+func getTimeStamp() string {
+	t := time.Now()
+	year, month, day := t.Date()
+	return fmt.Sprintf("[%d-%s-%d %d:%d:%d.%d]", year, month, day, t.Hour(), t.Minute(), t.Second(), t.Nanosecond())
 }

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -63,17 +63,18 @@ func (holder *AnnotationHolder) SetSupportedOpenShiftVersions(versions string) {
 }
 
 type verifier struct {
-	config           *viper.Viper
-	registry         checks.Registry
-	requiredChecks   []checks.Check
-	settings         *helmcli.EnvSettings
-	toolVersion      string
-	profile          *profiles.Profile
-	openshiftVersion string
-	providerDelivery bool
-	timeout          time.Duration
-	publicKeys       []string
-	values           map[string]interface{}
+	config             *viper.Viper
+	registry           checks.Registry
+	requiredChecks     []checks.Check
+	settings           *helmcli.EnvSettings
+	toolVersion        string
+	profile            *profiles.Profile
+	openshiftVersion   string
+	providerDelivery   bool
+	timeout            time.Duration
+	helmInstallTimeout time.Duration
+	publicKeys         []string
+	values             map[string]interface{}
 }
 
 func (c *verifier) subConfig(name string) *viper.Viper {
@@ -113,13 +114,14 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 			CertifiedOpenShiftVersionFlag: c.openshiftVersion}
 
 		r, checkErr := check.Func(&checks.CheckOptions{
-			HelmEnvSettings:  c.settings,
-			URI:              uri,
-			Values:           c.values,
-			ViperConfig:      c.subConfig(string(check.CheckId.Name)),
-			AnnotationHolder: &holder,
-			Timeout:          c.timeout,
-			PublicKeys:       c.publicKeys,
+			HelmEnvSettings:    c.settings,
+			URI:                uri,
+			Values:             c.values,
+			ViperConfig:        c.subConfig(string(check.CheckId.Name)),
+			AnnotationHolder:   &holder,
+			Timeout:            c.timeout,
+			HelmInstallTimeout: c.helmInstallTimeout,
+			PublicKeys:         c.publicKeys,
 		})
 
 		if checkErr != nil {

--- a/internal/chartverifier/verifierbuilder.go
+++ b/internal/chartverifier/verifierbuilder.go
@@ -67,6 +67,7 @@ type verifierBuilder struct {
 	providerDelivery            bool
 	timeout                     time.Duration
 	publicKeys                  []string
+	helmInstallTimeout          time.Duration
 	values                      map[string]interface{}
 	settings                    *cli.EnvSettings
 }
@@ -130,6 +131,11 @@ func (b *verifierBuilder) SetPublicKeys(publicKey []string) VerifierBuilder {
 	return b
 }
 
+func (b *verifierBuilder) SetHelmInstallTimeout(timeout time.Duration) VerifierBuilder {
+	b.helmInstallTimeout = timeout
+	return b
+}
+
 func (b *verifierBuilder) GetConfig() *viper.Viper {
 	return b.config
 }
@@ -160,17 +166,18 @@ func (b *verifierBuilder) Build() (Verifier, error) {
 	profile := profiles.Get()
 
 	return &verifier{
-		config:           b.config,
-		registry:         b.registry,
-		requiredChecks:   requiredChecks,
-		settings:         b.settings,
-		toolVersion:      b.toolVersion,
-		profile:          profile,
-		openshiftVersion: b.openshiftVersion,
-		providerDelivery: b.providerDelivery,
-		timeout:          b.timeout,
-		publicKeys:       b.publicKeys,
-		values:           b.values,
+		config:             b.config,
+		registry:           b.registry,
+		requiredChecks:     requiredChecks,
+		settings:           b.settings,
+		toolVersion:        b.toolVersion,
+		profile:            profile,
+		openshiftVersion:   b.openshiftVersion,
+		providerDelivery:   b.providerDelivery,
+		timeout:            b.timeout,
+		helmInstallTimeout: b.helmInstallTimeout,
+		publicKeys:         b.publicKeys,
+		values:             b.values,
 	}, nil
 }
 

--- a/internal/tool/kubectl_test.go
+++ b/internal/tool/kubectl_test.go
@@ -1,9 +1,16 @@
 package tool
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -69,4 +76,111 @@ func TestOCVersions(t *testing.T) {
 			t.Error(fmt.Sprintf("version mismatch, expected: %s, got: %s", testdata.OCVersion, ocVersion))
 		}
 	}
+}
+
+var testDeployments = []v1.Deployment{
+	{ObjectMeta: metav1.ObjectMeta{Name: "test0"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 1}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 2}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "test2"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 3}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "test3"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 4}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "test4"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 5}},
+	{ObjectMeta: metav1.ObjectMeta{Name: "test5"},
+		Status: v1.DeploymentStatus{UnavailableReplicas: 6}},
+}
+
+var (
+	DeploymentList1 []v1.Deployment
+)
+
+func TestWaitForDeployments(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListGood
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	k := new(Kubectl)
+	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	require.NoError(t, err)
+}
+
+func TestBadToGoodWaitForDeployments(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListBadToGood
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	k := new(Kubectl)
+	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	require.NoError(t, err)
+}
+
+func TestTimeExpirationWaitingForDeployments(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListGood
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	k := new(Kubectl)
+	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Error unavailable deployments, timeout has expired,")
+
+}
+
+func TestTimeExpirationGetDeploymentsFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListBad
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	k := new(Kubectl)
+	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Time out retrying after")
+	require.Contains(t, err.Error(), "error getting deployments from namespace")
+	require.Contains(t, err.Error(), "pretend error getting deployment list")
+
+}
+
+func deploymentTestListGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
+
+	fmt.Println("deploymentTestListGood called")
+	for index := 0; index < len(DeploymentList1); index++ {
+		if DeploymentList1[index].Status.UnavailableReplicas > 0 {
+			DeploymentList1[index].Status.UnavailableReplicas--
+			fmt.Println(fmt.Sprintf("UnavailableReplicas set to %d for deployment %s", DeploymentList1[index].Status.UnavailableReplicas, DeploymentList1[index].Name))
+		}
+	}
+	return DeploymentList1, nil
+}
+
+func deploymentTestListBad(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
+	fmt.Println("deploymentTestListBad called")
+	return nil, errors.New("pretend error getting deployment list")
+
+}
+
+var errorSent = false
+
+func deploymentTestListBadToGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
+	if !errorSent {
+		fmt.Println("deploymentTestListBadToGoodToBad bad path")
+		errorSent = true
+		return nil, errors.New("pretend error getting deployment list")
+	}
+	fmt.Println("deploymentTestListBadToGoodToBad good path")
+	return deploymentTestListGood(k, context, namespace, selector)
 }

--- a/pkg/chartverifier/verifier/verifier.go
+++ b/pkg/chartverifier/verifier/verifier.go
@@ -69,7 +69,8 @@ const (
 	ProviderDelivery BooleanKey = "provider-delivery"
 	SuppressErrorLog BooleanKey = "suppress-error-log"
 
-	Timeout DurationKey = "timeout"
+	Timeout            DurationKey = "timeout"
+	HelmInstallTimeout DurationKey = "helm-install-timeout"
 )
 
 var setStringKeys = [...]StringKey{KubeApiServer,
@@ -95,7 +96,7 @@ var setValuesKeys = [...]ValuesKey{CommandSet,
 
 var setBooleanKeys = [...]BooleanKey{ProviderDelivery, SuppressErrorLog}
 
-var setDurationKeys = [...]DurationKey{Timeout}
+var setDurationKeys = [...]DurationKey{Timeout, HelmInstallTimeout}
 
 type ApiVerifier interface {
 	SetBoolean(key BooleanKey, value bool) ApiVerifier
@@ -351,6 +352,10 @@ func (v *Verifier) Run(chart_uri string) (ApiVerifier, error) {
 
 	if stringsValue, ok := v.Inputs.Flags.StringFlags[PGPPublicKey]; ok {
 		runOptions.PublicKeys = stringsValue
+	}
+
+	if durationValue, ok := v.Inputs.Flags.DurationFlags[HelmInstallTimeout]; ok {
+		runOptions.HelmInstallTimeout = durationValue
 	}
 
 	runOptions.APIVersion = version.GetVersion()


### PR DESCRIPTION
- added new flag helm-install-timeout used to modify default timeout of 5 minutes
- added code so we wait for deployments after helm install and before starting the test
- add timestamp to log entries so can see how long each chart testing step takes. 
- updated docs