### PR TITLE
Fix issue where pyxis image lookups fail for RH TBR

### DIFF
--- a/internal/chartverifier/pyxis/pyxis.go
+++ b/internal/chartverifier/pyxis/pyxis.go
@@ -148,6 +148,10 @@ Loops:
 		nextPage := 0
 		allDataRead := false
 
+		// All Red Hat images are stored in pyxis under the registry.access.redhat.com URL
+		if registry == "registry.redhat.io" {
+			registry = "registry.access.redhat.com"
+		}
 		requestUrl := fmt.Sprintf("%s/registry/%s/repository/%s/images", pyxisBaseUrl, registry, imageRef.Repository)
 		utils.LogInfo(fmt.Sprintf("Search url: %s, tag: %s, sha: %s ", requestUrl, imageRef.Tag, imageRef.Sha))
 


### PR DESCRIPTION
Summary:
* Fixes an issue where Red Hat provided images fail pyxis API lookup if hosted in the Terms Based Registry (TBR)

Signed-off-by: Josh Manning <19478595+jsm84@users.noreply.github.com>