### PR TITLE
Update provider deliver flag to web catalog only

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -30,6 +30,7 @@ import (
 
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
+
 	//"helm.sh/helm/v3/pkg/getter"
 
 	"github.com/pkg/errors"
@@ -250,7 +251,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 	cmd.Flags().DurationVar(&clientTimeout, "timeout", 30*time.Minute, "time to wait for completion of chart install and test")
 	cmd.Flags().BoolVarP(&reportToFile, "write-to-file", "w", false, "write report to ./chartverifier/report.yaml (default: stdout)")
 	cmd.Flags().BoolVarP(&suppressErrorLog, "suppress-error-log", "E", false, "suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)")
-	cmd.Flags().BoolVarP(&providerDelivery, "provider-delivery", "d", false, "chart provider will provide the chart delivery mechanism (default: false)")
+	cmd.Flags().BoolVarP(&providerDelivery, "web-catalog-only", "W", false, "set this to indicate that the distribution method is web catalog only (default: false)")
 	cmd.Flags().StringVarP(&pgpPublicKeyFile, "pgp-public-key", "k", "", "file containing gpg public key of the key used to sign the chart")
 	cmd.Flags().DurationVar(&helmInstallTimeout, "helm-install-timeout", 5*time.Minute, "helm install timeout")
 	return cmd

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -189,7 +189,7 @@ func TestCertify(t *testing.T) {
 
 	})
 
-	t.Run("should see providerControlledDelivery is true for -d flag and chart-uri is not set", func(t *testing.T) {
+	t.Run("should see providerControlledDelivery is true for -W flag and chart-uri is not set", func(t *testing.T) {
 
 		cmd := NewVerifyCmd(viper.New())
 		outBuf := bytes.NewBufferString("")
@@ -200,7 +200,7 @@ func TestCertify(t *testing.T) {
 		cmd.SetArgs([]string{
 			"-e", "has-readme", // only consider a single check, perhaps more checks in the future
 			"../internal/chartverifier/checks/chart-0.1.0-v3.valid.tgz",
-			"-d",
+			"-W",
 			"-E"})
 
 		require.NoError(t, cmd.Execute())
@@ -215,7 +215,7 @@ func TestCertify(t *testing.T) {
 
 	})
 
-	t.Run("should see providerControlledDelivery is false if no -d flag and chart-uri is set", func(t *testing.T) {
+	t.Run("should see providerControlledDelivery is false if no -W flag and chart-uri is set", func(t *testing.T) {
 
 		cmd := NewVerifyCmd(viper.New())
 		outBuf := bytes.NewBufferString("")

--- a/docs/helm-chart-checks.md
+++ b/docs/helm-chart-checks.md
@@ -143,7 +143,7 @@ This section provides help on the basic usage of Helm chart checks with the podm
     -V, --openshift-version string    set the value of certifiedOpenShiftVersions in the report
     -o, --output string               the output format: default, json or yaml
     -k, --pgp-public-key string       file containing gpg public key of the key used to sign the chart  
-    -d, --provider-delivery           chart provider will provide the chart delivery mechanism (default: false)
+    -W, --web-catalog-only            set this to indicate that the distribution method is web catalog only (default: false)
         --registry-config string      path to the registry config file (default "/home/baiju/.config/helm/registry.json")
         --repository-cache string     path to the file containing cached repository indexes (default "/home/baiju/.cache/helm/repository")
         --repository-config string    path to the file containing repository names and URLs (default "/home/baiju/.config/helm/repositories.yaml")

--- a/docs/helm-chart-submission.md
+++ b/docs/helm-chart-submission.md
@@ -1,6 +1,7 @@
 
 # Submission of Helm charts for Red Hat OpenShift certification
  - [Submission options](#submission-options)
+ - [Helm Chart Distribution methods](#helm-chart-distribution-methods)
  - [Provider controlled delivery](#provider-controlled-delivery)
 
 ## Submission options
@@ -29,36 +30,49 @@ For more information on the submission process, see: [OpenShift Helm Charts Repo
 
 For troubleshooting report related submission failures see: [Troubleshooting](./helm-chart-troubleshooting.md)
 
-## Provider controlled delivery
+## Helm Chart Distribution methods:
 
-By default, a submitted chart will be made available in the OpenShift Helm Chart Catalog on successful certification. In some cases this is undesirable and can be prevented using provider controlled delivery. With provider controlled delivery the provider of the chart controls access to the chart and this impacts report generation:
+There are three methods of distribution for certified helm charts.
+
+- Publish your chart in the Red Hat Helm Chart repository
+  - Submissions should include either a chart or chart and report.
+- Publish you chart in your own Helm Chart repository
+  - Submissions should be report only using a publicly available chart URL.
+- Web catalog only
+  - This submission should be report only using a private chart URL.
+
+For more information on the different Helm Chart Distribution methods, see: [Creating a Helm Chart Certification Project](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/creating-a-helm-chart-certification-project)
+
+## Web catalog only delivery
+
+Web catalog only delivery was previously described as provider delivery. Chart submissions will be made available within the Helm Chart Catalog on successful certifications. In the event that this case is undisirable, the provider should consider the web catalog only option if they wish not to make the chart publicly available. With web catalog only delivery the provider of the chart controls access to the chart and this will impact report generation:
 
 - The report must be generated using a tarball so that a package digest can be determined and included in the report.
   - if a tarball is not used the report will fail to generate.
 - The chart URL may be considered private to the provider so the chart URL is not included in the report.
 
-Provider controlled delivery is then based on the following conditions: 
+Web catalog only delivery is then based on the following conditions: 
 
-1. When generating the Verification report the ```--provider-delivery``` flag is used.
+1. When generating the Verification report the ```--web-catalog-only``` flag is used.
    Example:
     ```
     $ podman run --rm -i                                  \
           -e KUBECONFIG=/.kube/config                   \
           -v "${HOME}/.kube":/.kube                     \
           "quay.io/redhat-certification/chart-verifier" \
-          verify --provider-delivery                    \
+          verify --web-catalog-only                     \
           <chart-uri>
     ```
     This ensures that the [providerControlledDelivery annotation](helm-chart-annotations.md#providerControlledDelivery) is set to the value True in the verification report.
 
-1. The OWNERS file for the submitted chart in the [openshift helm charts github repository](https://github.com/openshift-helm-charts/charts) includes a ```providerDelivery``` attribute which is set to the value True. 
+1. The OWNERS file for the submitted chart in the [openshift helm charts github repository](https://github.com/openshift-helm-charts/charts) includes a ```webCatalogOnly``` attribute which is set to the value True. 
    Example:
 ```
 chart:
   name: mychart
   shortDescription: Test chart for testing chart submission workflows.
 publicPgpKey: null
-providerDelivery: True
+webCatalogOnly: True
 users:
 - githubUsername: myusername
 vendor:

--- a/docs/helm-chart-submission.md
+++ b/docs/helm-chart-submission.md
@@ -65,14 +65,14 @@ Web catalog only delivery is then based on the following conditions:
     ```
     This ensures that the [providerControlledDelivery annotation](helm-chart-annotations.md#providerControlledDelivery) is set to the value True in the verification report.
 
-1. The OWNERS file for the submitted chart in the [openshift helm charts github repository](https://github.com/openshift-helm-charts/charts) includes a ```webCatalogOnly``` attribute which is set to the value True. 
+1. The OWNERS file for the submitted chart in the [openshift helm charts github repository](https://github.com/openshift-helm-charts/charts) includes a ```providerDelivery``` attribute which is set to the value True. 
    Example:
 ```
 chart:
   name: mychart
   shortDescription: Test chart for testing chart submission workflows.
 publicPgpKey: null
-webCatalogOnly: True
+providerDelivery: True
 users:
 - githubUsername: myusername
 vendor:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/HELM-461

Updates the provider delivery flag to instead say web catalog only.

Mentions of provider delivery have led to some confusions with users. This is due to the fact that the [Creating a Helm Chart Certification Project](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/helm-chart-certification/creating-a-helm-chart-certification-project) article does not have any mentions of a provider delivery distribution method. In our case provider delivery is the same as the web catalog only distribution method.

Also updated the unit test that utilizes the provider delivery flag to now match the updates from this PR.