### PR TITLE
Deprecation of set-output

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -92,7 +92,7 @@ jobs:
             - name: Get Date
               id: get-date
               run: |
-                echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+                echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
               shell: bash
 
             - uses: actions/cache@v2
@@ -128,7 +128,7 @@ jobs:
                   image_tag="podman-"$commit_sha
                   echo "use image tag $image_tag"
                   podman build -t quay.io/redhat-certification/chart-verifier:$image_tag .
-                  echo "::set-output name=podman_image_tag::$image_tag"
+                  echo "podman_image_tag=$image_tag" >> $GITHUB_OUTPUT
 
             - name: Create tarfile
               id: create-tarfile

--- a/scripts/src/buildandtest/buildandtest.py
+++ b/scripts/src/buildandtest/buildandtest.py
@@ -23,6 +23,7 @@ except ImportError:
 
 sys.path.append('./scripts/src/')
 from report import report_info
+from utils import utils
 
 def build_image(image_id):
     print(f"Build Image : {image_id}")
@@ -103,7 +104,7 @@ def test_image(image_id,chart,verifier_version):
 
 def main():
 
-    print("::set-output name=result::failure")
+    utils.add_output("result","failure")
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-i", "--image-name", dest="image_name", type=str, required=True,
@@ -122,7 +123,7 @@ def main():
 
     if build_image(image_id):
 
-        print(f'::set-output name=verifier-image-tag::{args.sha_value}')
+        utils.add_output("verifier-image-tag",args.sha_value)
 
         if not args.build_only:
 

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -32,6 +32,7 @@ import semver
 import sys
 sys.path.append('./scripts/src/')
 from release import tarfile_asset
+from utils import utils
 
 VERSION_FILE = 'pkg/chartverifier/version/version_info.json'
 
@@ -73,7 +74,7 @@ def make_release_body(version, image_name, release_info):
             body += f"- {info}<br>"
 
     print(f"[INFO] Release body: {body}")
-    print(f"::set-output name=PR_release_body::{body}")
+    utils.add_output("PR_release_body",body)
 
 def get_version_info():
     data = {}
@@ -102,14 +103,14 @@ def main():
         version_info = get_version_info()
         asset_file = tarfile_asset.create(version_info["version"])
         print(f'[INFO] Verifier tarball created : {asset_file}.')
-        print(f'::set-output name=PR_tarball_name::{asset_file}')
+        utils.add_output("PR_tarball_name",asset_file)
         if check_if_only_version_file_is_modified(args.api_url):
             ## should be on PR branch
             print(f'[INFO] Release found in PR files : {version_info["version"]}.')
-            print(f'::set-output name=PR_version::{version_info["version"]}')
-            print(f'::set-output name=PR_release_image::{version_info["quay-image"]}')
-            print(f'::set-output name=PR_release_info::{version_info["release-info"]}')
-            print(f'::set-output name=PR_includes_release::true')
+            utils.add_output("PR_version",version_info["version"])
+            utils.add_output("PR_release_image",version_info["quay-image"])
+            utils.add_output("PR_release_info",version_info["release-info"])
+            utils.add_output("PR_includes_release","true")
             make_release_body(version_info["version"],version_info["quay-image"],version_info["release-info"])
     else:
         version_info = get_version_info()
@@ -118,13 +119,13 @@ def main():
             version_compare = semver.compare(args.version,version_info["version"])
             if version_compare > 0 :
                 print(f'[INFO] Release {args.version} found in PR files is newer than: {version_info["version"]}.')
-                print("::set-output name=updated::true")
+                utils.add_output("updated","true")
             elif version_compare == 0 and not release_exists(args.version):
                 print(f'[INFO] Release {args.version} found in PR files is not new but no release exists yet.')
-                print("::set-output name=updated::true")
+                utils.add_output("updated","true")
             else:
                 print(f'[INFO] Release found in PR files is not new  : {version_info["version"]} already exists.')
         else:
-            print(f'::set-output name=PR_version::{version_info["version"]}')
-            print(f'::set-output name=PR_release_image::{version_info["quay-image"]}')
+            utils.add_output("PR_version",version_info["version"])
+            utils.add_output("PR_release_image",version_info["quay-image"])
             print("[INFO] PR contains non-release files.")

--- a/scripts/src/release/tarfile_asset.py
+++ b/scripts/src/release/tarfile_asset.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 import tarfile
-
+from utils import utils
 
 tar_content_files = [ {"name": "out/chart-verifier", "arc_name": "chart-verifier"} ]
 
@@ -9,7 +9,7 @@ tar_content_files = [ {"name": "out/chart-verifier", "arc_name": "chart-verifier
 def create(release):
 
     tgz_name = f"chart-verifier-{release}.tgz"
-    print(f'::set-output name=tarball_base_name::{tgz_name}')
+    utils.add_output("tarball_base_name",tgz_name)
 
     if os.path.exists(tgz_name):
         os.remove(tgz_name)
@@ -29,5 +29,5 @@ def main():
     args = parser.parse_args()
     tarfile = create(args.release)
     print(f'[INFO] Verifier tarball created : {tarfile}.')
-    print(f'::set-output name=tarball_full_name::{tarfile}')
+    utils.add_output("tarball_full_name",tarfile)
 

--- a/scripts/src/utils/utils.py
+++ b/scripts/src/utils/utils.py
@@ -1,0 +1,5 @@
+import os
+
+def add_output(name,value):
+    with open(os.environ['GITHUB_OUTPUT'],'a') as fh:
+        print(f'{name}={value}',file=fh)


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/HELM-438

Removes the deprecated set-output in favor for GITHUB_OUTPUT

The workflows and associated scripts make extensive use of set-output, but it is now being deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR removes set-output and replaces it with GITHUB_OUTPUT within the workflow. It also introduces a utils module that will handle adding the output to GITHUB_OUTPUT for the python scripts.

