### PR TITLE
Fix error in link image script

### DIFF
--- a/scripts/src/quay/linkimages.py
+++ b/scripts/src/quay/linkimages.py
@@ -64,7 +64,7 @@ def get_image_id(tag_value, do_retry):
         print("[INFO] loaded the tags")
         for tag in tags["tags"]:
             if tag['name'] == tag_value:
-                image_id = tag['image_id']
+                image_id = tag['manifest_digest']
                 print(f"[INFO] Found tag {tag_value}. image_id : {image_id}")
                 break
             else:


### PR DESCRIPTION
In the release image tag linking was not working because the response fro pyxis no longer includes an ```image_id``` attribute. This cause an exception and the retry logic kicks in. Have changed this to use ```manifest_digest``` instead. Ran the script locally to ensure it works.