### PR TITLE
export the version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,10 +11,10 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(NewVersionCmd())
 }
 
-func newVersionCmd() *cobra.Command {
+func NewVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "print the chart-verifier version information",


### PR DESCRIPTION
The other cobra commands are exported. This would just export Version as well, and just helps throw together Preflight + Chart-Verifier PoCs.

Signed-off-by: Jose R. Gonzalez <jrg@redhat.com>