### PR TITLE
Ensure the chart's verifier-version matches the verifier version subcommand output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea/
 /out/
 **/reports/
+__pycache__

--- a/tests/tests/functional/features/chart_good.feature
+++ b/tests/tests/functional/features/chart_good.feature
@@ -13,6 +13,7 @@ Feature: Chart verification
         Given I will provide a <location> of a <helm_chart>
         Given I will provide a <location> of an expected <report_info>
         Given I will use the chart verifier <image_type> image
+        Given The chart verifier version value
         When I run the chart-verifier verify command against the chart to generate a report
         Then I should see the report-info from the generated report matching the expected report-info
 
@@ -31,6 +32,7 @@ Feature: Chart verification
         Given I will provide a <location> of an expected <report_info>
         Given I will use the chart verifier <image_type> image
         Given I will provide a <location> of a <public_key> to verify the signature
+        Given The chart verifier version value
         When I run the chart-verifier verify command against the signed chart to generate a report
         Then I should see the report-info from the report for the signed chart matching the expected report-info
 


### PR DESCRIPTION
The chart-verifier container image 1.8.0 would produce reports that reported a `.metadata.tool.verifier-version` of 1.0.0.

This PR adds an extension of the BDD that would check the charts produced against the version output of the built binary/image's `version` subcommand to make sure that they align.

The original scoped implementation suggested doing this at the point where a release asset is to be given the `latest` tag, but we don't technically have a produced report at that time. Instead, we do the comparison earlier when we're actively using the binary/image to test known-good charts, and verify their reports.

Signed-off-by: Jose R. Gonzalez <jrg@redhat.com>

Related: [HELM-422](https://issues.redhat.com/browse/HELM-422)