### PR TITLE
disable gosec alert on reading http.Body

### DIFF
--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -500,6 +500,7 @@ func downloadFile(fileURL *url.URL, directory string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// #nosec G307
 	defer resp.Body.Close()
 
 	_, err = io.Copy(file, resp.Body)

--- a/internal/chartverifier/pyxis/pyxis.go
+++ b/internal/chartverifier/pyxis/pyxis.go
@@ -98,6 +98,7 @@ func GetImageRegistries(repository string) ([]string, error) {
 			err = errors.New(fmt.Sprintf("Error getting repository %s : %v\n", repository, err))
 		} else {
 			if resp.StatusCode == 200 {
+				// #nosec G307
 				defer resp.Body.Close()
 				body, _ := ioutil.ReadAll(resp.Body)
 				var repositoriesBody RepositoriesBody
@@ -165,6 +166,7 @@ Loops:
 
 			if reqErr == nil {
 				if resp.StatusCode == 200 {
+					// #nosec G307
 					defer resp.Body.Close()
 					body, _ := ioutil.ReadAll(resp.Body)
 					var registriesBody RegistriesBody


### PR DESCRIPTION
It seems that defer close on the io.ReadCloser returned by an http.Body is starting to trigger GoSec's policy on defering close functions which is being considered as a potential point of errors[1].

Put simply, because Close functions can return an error, deferring it can cause weird behaviors, particularly with Closers associated with Writers (e.g. writing a file). 

In this particular case, I don't think we're concerned with this for our http.Body structs, so in effect, I've applied the override for those  places. This same override is also elsewhere in our code.

This issue is also causing failures in CI testing across several PRs.

Signed-off-by: Jose R. Gonzalez <jrg@redhat.com>

---

[1] https://github.com/securego/gosec/issues/925