### PR TITLE
Extend makefile to add new go developer tooling helpers and downloaders

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,50 @@
+run:
+  # Default timeout is 1m, up to give more room
+  timeout: 4m
+
+linters:
+  enable:
+  - asciicheck
+  - deadcode
+  - depguard
+  - gofumpt
+  - goimports
+  - importas
+  - revive
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - unparam
+  - whitespace
+
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/api/pkg/operators/v1alpha1
+      alias: operatorsv1alpha1
+    - pkg: github.com/operator-framework/api/pkg/operators/v1
+      alias: operatorsv1
+    - pkg: github.com/openshift/api/image/v1
+      alias: imagestreamv1
+  revive:
+    rules:
+    - name: dot-imports
+      severity: warning
+      disabled: true
+  stylecheck:
+    dot-import-whitelist:
+      - github.com/onsi/gomega
+      - github.com/onsi/ginkgo
+      - github.com/onsi/ginkgo/v2
+  goimports:
+    local-prefixes: github.com/redhat-certification/chart-verifier
+
+output:
+  format: tab

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,20 @@ gomod_tidy:
 gofmt:
 	go fmt -x ./...
 
+.PHONY: fmt
+fmt: install.gofumpt
+	# -l: list files whose formatting differs from gofumpt's
+	# -w: write results to source files instead of stdout
+	${GOFUMPT} -l -w . 
+	git diff --exit-code
+
 .PHONY: bin
 bin:
 	 go build -o ./out/chart-verifier main.go
+
+.PHONY: lint
+lint: install.golangci-lint
+	$(GOLANGCI_LINT) run
 
 .PHONY: bin_win
 bin_win:
@@ -29,8 +40,29 @@ build-image:
 	hack/build-image.sh
 
 .PHONY: gosec
-gosec:
-	# Run this command to install gosec, if not installed:
-	# export PATH=$PATH:$(go env GOPATH)/bin
-	# go install github.com/securego/gosec/v2/cmd/gosec@latest
-	gosec -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir tests ./...
+gosec: install.gosec
+	$(GOSEC) -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir tests ./...
+
+# Developer Tooling Installation
+GOSEC = $(shell pwd)/out/gosec
+GOSEC_VERSION ?= latest
+install.gosec: 
+	$(call go-install-tool,$(GOSEC),github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION))
+
+GOFUMPT = $(shell pwd)/out/gofumpt
+install.gofumpt:
+	$(call go-install-tool,$(GOFUMPT),mvdan.cc/gofumpt@latest)
+
+GOLANGCI_LINT = $(shell pwd)/out/golangci-lint
+GOLANGCI_LINT_VERSION ?= v1.50.0
+install.golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT):
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))\
+
+# go-install-tool will 'go install' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-install-tool
+@[ -f $(1) ] || { \
+GOBIN=$(PROJECT_DIR)/out go install $(2) ;\
+}
+endef


### PR DESCRIPTION
Adds Makefile Targets For:

- Installing `gofumpt`, `golangci-lint`, and `gosec`
- Running `gofumpt` instead of `go fmt`. This isn't fully wired up so that GitHub Actions execute them because I believe we should apply them to the codebase before we force them using Actions.