### PR TITLE
Apply gofumpt and golangci-lint to reportsummary package

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -38,13 +38,13 @@ func NewReportCmd(config *viper.Viper) *cobra.Command {
 		Short: "Provides information from a report",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reportName := ""
-			reportFormat := apireportsummary.JsonReport
+			reportFormat := apireportsummary.JSONReport
 			if reportToFile {
 				if outputFormatFlag == "json" {
 					reportName = "report-info.json"
 				} else {
 					reportName = "report-info.yaml"
-					reportFormat = apireportsummary.YamlReport
+					reportFormat = apireportsummary.YAMLReport
 				}
 			}
 			utils.InitLog(cmd, reportName, true)

--- a/pkg/chartverifier/report/report.go
+++ b/pkg/chartverifier/report/report.go
@@ -166,7 +166,7 @@ func (r *Report) checkReportDigest() error {
 	if semver.Compare(reportVersion, ReportShaVersion) >= 0 {
 		digestFromReport := r.Metadata.ToolMetadata.ReportDigest
 		if digestFromReport == "" {
-			return errors.New("Report does not contain expected report digest. ")
+			return errors.New("report does not contain expected report digest")
 		}
 
 		calculatedDigest, err := r.GetReportDigest()

--- a/pkg/chartverifier/reportsummary/reportSummary.go
+++ b/pkg/chartverifier/reportsummary/reportSummary.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 const (
@@ -78,7 +79,6 @@ func (r *ReportSummary) SetBoolean(key BooleanKey, value bool) APIReportSummary 
 }
 
 func (r *ReportSummary) GetContent(summary SummaryType, format SummaryFormat) (string, error) {
-
 	generateSummary := (r.MetadataReport == nil) || (r.ResultsReport == nil) || (r.AnnotationsReport == nil) || (r.DigestsReport == nil)
 
 	if generateSummary {
@@ -136,16 +136,13 @@ func (r *ReportSummary) GetContent(summary SummaryType, format SummaryFormat) (s
 }
 
 func (r *ReportSummary) addAll() {
-
 	r.addAnnotations()
 	r.addDigests()
 	r.addResults()
 	r.addMetadata()
-
 }
 
 func (r *ReportSummary) addAnnotations() {
-
 	anotationsPrefix := DefaultAnnotationsPrefix
 
 	if configAnnotationsPrefix, ok := r.options.values[AnnotationsPrefixConfigName]; ok {
@@ -196,33 +193,27 @@ func (r *ReportSummary) addAnnotations() {
 		annotation.Value = value
 		r.AnnotationsReport = append(r.AnnotationsReport, annotation)
 	}
-
 }
 
 func (r *ReportSummary) addDigests() {
-
 	r.DigestsReport = &DigestReport{}
 	r.DigestsReport.ChartDigest = r.options.report.Metadata.ToolMetadata.Digests.Chart
 	r.DigestsReport.PackageDigest = r.options.report.Metadata.ToolMetadata.Digests.Package
 	if len(r.options.report.Metadata.ToolMetadata.Digests.PublicKey) > 0 {
 		r.DigestsReport.PublicKeyDigest = r.options.report.Metadata.ToolMetadata.Digests.PublicKey
 	}
-
 }
 
 func (r *ReportSummary) addMetadata() {
-
 	r.MetadataReport = &MetadataReport{}
 	r.MetadataReport.ProfileVendorType = profiles.VendorType(r.options.report.Metadata.ToolMetadata.Profile.VendorType)
 	r.MetadataReport.ProfileVersion = r.options.report.Metadata.ToolMetadata.Profile.Version
 	r.MetadataReport.ChartUri = r.options.report.Metadata.ToolMetadata.ChartUri
 	r.MetadataReport.Chart = r.options.report.Metadata.ChartData
 	r.MetadataReport.WebCatalogOnly = r.options.report.Metadata.ToolMetadata.ProviderDelivery || r.options.report.Metadata.ToolMetadata.WebCatalogOnly
-
 }
 
 func (r *ReportSummary) addResults() {
-
 	profileVendorType := r.options.report.Metadata.ToolMetadata.Profile.VendorType
 	profileVersion := r.options.report.Metadata.ToolMetadata.Profile.Version
 
@@ -278,11 +269,9 @@ func (r *ReportSummary) addResults() {
 	r.ResultsReport.Passed = fmt.Sprintf("%d", passed)
 	r.ResultsReport.Failed = fmt.Sprintf("%d", failed)
 	r.ResultsReport.Messages = messages
-
 }
 
 func (r *ReportSummary) checkReportDigest() error {
-
 	toolMetadata := r.options.report.Metadata.ToolMetadata
 	reportVersion := fmt.Sprintf("v%s", toolMetadata.Version)
 
@@ -303,5 +292,4 @@ func (r *ReportSummary) checkReportDigest() error {
 
 	}
 	return nil
-
 }

--- a/pkg/chartverifier/reportsummary/reportsummary_test.go
+++ b/pkg/chartverifier/reportsummary/reportsummary_test.go
@@ -1,9 +1,8 @@
 package reportsummary
 
 import (
-	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestAddStringReport(t *testing.T) {
-	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
+	chartURI := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/report.yaml"
 	jsonFileReport := "test-reports/report.json"
 
@@ -26,12 +25,12 @@ func TestAddStringReport(t *testing.T) {
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary := NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 }
 
 func TestBadDigestReport(t *testing.T) {
@@ -45,19 +44,19 @@ func TestBadDigestReport(t *testing.T) {
 
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
-	_, summaryErr := NewReportSummary().SetReport(report).GetContent(AllSummary, YamlReport)
+	_, summaryErr := NewReportSummary().SetReport(report).GetContent(AllSummary, YAMLReport)
 	require.Error(t, summaryErr)
 	require.Contains(t, fmt.Sprintf("%v", summaryErr), "digest in report did not match report content")
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
-	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JsonReport)
+	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JSONReport)
 	require.Error(t, summaryErr)
 	require.Contains(t, fmt.Sprintf("%v", summaryErr), "digest in report did not match report content")
 }
 
 func TestSkipBadDigestReport(t *testing.T) {
-	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
+	chartURI := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/baddigest/report.yaml"
 	jsonFileReport := "test-reports/baddigest/report.json"
 
@@ -69,12 +68,12 @@ func TestSkipBadDigestReport(t *testing.T) {
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary := NewReportSummary().SetReport(report).SetBoolean(SkipDigestCheck, true)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report).SetBoolean(SkipDigestCheck, true)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 }
 
 func TestMissingDigestReport(t *testing.T) {
@@ -88,19 +87,19 @@ func TestMissingDigestReport(t *testing.T) {
 
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
-	_, summaryErr := NewReportSummary().SetReport(report).GetContent(AllSummary, YamlReport)
+	_, summaryErr := NewReportSummary().SetReport(report).GetContent(AllSummary, YAMLReport)
 	require.Error(t, summaryErr)
-	require.Contains(t, fmt.Sprintf("%v", summaryErr), "Report does not contain expected report digest.")
+	require.Contains(t, fmt.Sprintf("%v", summaryErr), "report does not contain expected report digest")
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
-	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JsonReport)
+	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JSONReport)
 	require.Error(t, summaryErr)
-	require.Contains(t, fmt.Sprintf("%v", summaryErr), "Report does not contain expected report digest.")
+	require.Contains(t, fmt.Sprintf("%v", summaryErr), "report does not contain expected report digest")
 }
 
 func TestPreDigestReport(t *testing.T) {
-	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
+	chartURI := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/predigest/report.yaml"
 	jsonFileReport := "test-reports/predigest/report.json"
 
@@ -112,16 +111,16 @@ func TestPreDigestReport(t *testing.T) {
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary := NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 }
 
 func TestProviderDeliveryReport(t *testing.T) {
-	chartUri := "N/A"
+	chartURI := "N/A"
 	yamlFileReport := "test-reports/providerdelivery/report.yaml"
 	jsonFileReport := "test-reports/providerdelivery/report.json"
 
@@ -133,70 +132,70 @@ func TestProviderDeliveryReport(t *testing.T) {
 	report, loadErr := apireport.NewReport().SetContent(string(yamlFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary := NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 
 	report, loadErr = apireport.NewReport().SetContent(string(jsonFileReportBytes)).Load()
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 }
 
 func TestAddUrlReport(t *testing.T) {
-	yamlUrlReport := "https://github.com/redhat-certification/chart-verifier/blob/main/cmd/test/report.yaml?raw=true"
-	url, loadUrlErr := url.Parse(yamlUrlReport)
-	require.NoError(t, loadUrlErr)
+	yamlURLReport := "https://github.com/redhat-certification/chart-verifier/blob/main/cmd/test/report.yaml?raw=true"
+	url, loadURLErr := url.Parse(yamlURLReport)
+	require.NoError(t, loadURLErr)
 
-	chartUri := "internal/chartverifier/checks/chart-0.1.0-v3.valid.tgz"
+	chartURI := "internal/chartverifier/checks/chart-0.1.0-v3.valid.tgz"
 	report, loadErr := apireport.NewReport().SetURL(url).Load()
 	require.NoError(t, loadErr)
 	reportSummary := NewReportSummary().SetReport(report)
 
-	checkReportSummaries(reportSummary, chartUri, t)
+	checkReportSummaries(reportSummary, chartURI, t)
 }
 
-func checkReportSummaries(summary APIReportSummary, chartUri string, t *testing.T) {
-	checkReportSummariesFormat(YamlReport, summary, chartUri, t)
-	checkReportSummariesFormat(JsonReport, summary, chartUri, t)
+func checkReportSummaries(summary APIReportSummary, chartURI string, t *testing.T) {
+	checkReportSummariesFormat(YAMLReport, summary, chartURI, t)
+	checkReportSummariesFormat(JSONReport, summary, chartURI, t)
 }
 
-func checkReportSummariesFormat(format SummaryFormat, summary APIReportSummary, chartUri string, t *testing.T) {
+func checkReportSummariesFormat(format SummaryFormat, summary APIReportSummary, chartURI string, t *testing.T) {
 	reportSummary, reportSummaryErr := summary.GetContent(AllSummary, format)
 	require.NoError(t, reportSummaryErr)
-	checkSummaryAll(format, reportSummary, chartUri, t)
+	checkSummaryAll(format, reportSummary, chartURI, t)
 
 	reportSummary, reportSummaryErr = summary.GetContent(DigestsSummary, format)
 	require.NoError(t, reportSummaryErr)
-	checkSummaryDigests(false, format, reportSummary, chartUri, t)
+	checkSummaryDigests(false, format, reportSummary, chartURI, t)
 
 	reportSummary, reportSummaryErr = summary.GetContent(MetadataSummary, format)
 	require.NoError(t, reportSummaryErr)
-	checkSummaryMetadata(false, format, reportSummary, chartUri, t)
+	checkSummaryMetadata(false, format, reportSummary, chartURI, t)
 
 	reportSummary, reportSummaryErr = summary.GetContent(AnnotationsSummary, format)
 	require.NoError(t, reportSummaryErr)
-	checkSummaryAnnotations(false, format, reportSummary, chartUri, t)
+	checkSummaryAnnotations(false, format, reportSummary, chartURI, t)
 
 	reportSummary, reportSummaryErr = summary.GetContent(ResultsSummary, format)
 	require.NoError(t, reportSummaryErr)
-	checkSummaryResults(false, format, reportSummary, chartUri, t)
+	checkSummaryResults(false, format, reportSummary, chartURI, t)
 }
 
-func checkSummaryAll(format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
-	checkSummaryAnnotations(true, format, reportSummary, chartUri, t)
-	checkSummaryDigests(true, format, reportSummary, chartUri, t)
-	checkSummaryMetadata(true, format, reportSummary, chartUri, t)
-	checkSummaryResults(true, format, reportSummary, chartUri, t)
+func checkSummaryAll(format SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
+	checkSummaryAnnotations(true, format, reportSummary, chartURI, t)
+	checkSummaryDigests(true, format, reportSummary, chartURI, t)
+	checkSummaryMetadata(true, format, reportSummary, chartURI, t)
+	checkSummaryResults(true, format, reportSummary, chartURI, t)
 }
 
-func checkSummaryResults(fullReport bool, format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
-	if format == JsonReport {
+func checkSummaryResults(fullReport bool, format SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
+	if format == JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"digests\":{")
 			require.NotContains(t, reportSummary, "\"metadata\":{")
 			require.NotContains(t, reportSummary, "\"name\":\"charts.openshift.io/digest\"")
 			require.NotContains(t, reportSummary, "\"chart\":\"sha256")
-			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartUri+"\"")
+			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartURI+"\"")
 		}
 		require.Contains(t, reportSummary, "\"results\":{")
 		require.Contains(t, reportSummary, "\"passed\":")
@@ -207,23 +206,22 @@ func checkSummaryResults(fullReport bool, format SummaryFormat, reportSummary st
 			require.NotContains(t, reportSummary, "metadata:")
 			require.NotContains(t, reportSummary, "- name: charts.openshift.io/digest")
 			require.NotContains(t, reportSummary, "chart: sha256:")
-			require.NotContains(t, reportSummary, "chart-uri: "+chartUri)
+			require.NotContains(t, reportSummary, "chart-uri: "+chartURI)
 		}
 		require.Contains(t, reportSummary, "results:")
 		require.Contains(t, reportSummary, "passed:")
 		require.Contains(t, reportSummary, "failed:")
-
 	}
 }
 
-func checkSummaryAnnotations(fullReport bool, format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
-	if format == JsonReport {
+func checkSummaryAnnotations(fullReport bool, format SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
+	if format == JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"digests\":{")
 			require.NotContains(t, reportSummary, "\"metadata\":{")
 			require.NotContains(t, reportSummary, "\"results\":{")
 			require.NotContains(t, reportSummary, "\"chart\":\"sha256")
-			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartUri+"\"")
+			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartURI+"\"")
 			require.NotContains(t, reportSummary, "\"passed\":")
 			require.NotContains(t, reportSummary, "\"failed\":")
 		}
@@ -235,7 +233,7 @@ func checkSummaryAnnotations(fullReport bool, format SummaryFormat, reportSummar
 			require.NotContains(t, reportSummary, "metadata:")
 			require.NotContains(t, reportSummary, "results:")
 			require.NotContains(t, reportSummary, "chart: sha256:")
-			require.NotContains(t, reportSummary, "chart-uri: "+chartUri)
+			require.NotContains(t, reportSummary, "chart-uri: "+chartURI)
 			require.NotContains(t, reportSummary, "passed:")
 			require.NotContains(t, reportSummary, "failed:")
 		}
@@ -244,8 +242,8 @@ func checkSummaryAnnotations(fullReport bool, format SummaryFormat, reportSummar
 	}
 }
 
-func checkSummaryMetadata(fullReport bool, format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
-	if format == JsonReport {
+func checkSummaryMetadata(fullReport bool, format SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
+	if format == JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"digests\":{")
@@ -256,7 +254,7 @@ func checkSummaryMetadata(fullReport bool, format SummaryFormat, reportSummary s
 			require.NotContains(t, reportSummary, "\"failed\":")
 		}
 		require.Contains(t, reportSummary, "\"metadata\":{")
-		require.Contains(t, reportSummary, "\"chart-uri\":\""+chartUri+"\"")
+		require.Contains(t, reportSummary, "\"chart-uri\":\""+chartURI+"\"")
 		require.Contains(t, reportSummary, "\"webCatalogOnly\":")
 	} else {
 		if !fullReport {
@@ -268,18 +266,18 @@ func checkSummaryMetadata(fullReport bool, format SummaryFormat, reportSummary s
 			require.NotContains(t, reportSummary, "failed:")
 		}
 		require.Contains(t, reportSummary, "metadata:")
-		require.Contains(t, reportSummary, "chart-uri: "+chartUri)
+		require.Contains(t, reportSummary, "chart-uri: "+chartURI)
 	}
 }
 
-func checkSummaryDigests(fullReport bool, format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
-	if format == JsonReport {
+func checkSummaryDigests(fullReport bool, format SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
+	if format == JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"metadata\":{")
 			require.NotContains(t, reportSummary, "\"results\":{")
 			require.NotContains(t, reportSummary, "\"name\":\"charts.openshift.io/digest\"")
-			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartUri+"\"")
+			require.NotContains(t, reportSummary, "\"chart-uri\":\""+chartURI+"\"")
 			require.NotContains(t, reportSummary, "\"passed\":")
 			require.NotContains(t, reportSummary, "\"failed\":")
 		}
@@ -291,7 +289,7 @@ func checkSummaryDigests(fullReport bool, format SummaryFormat, reportSummary st
 			require.NotContains(t, reportSummary, "metadata:")
 			require.NotContains(t, reportSummary, "results:")
 			require.NotContains(t, reportSummary, "- name: charts.openshift.io/digest")
-			require.NotContains(t, reportSummary, "chart-uri: "+chartUri)
+			require.NotContains(t, reportSummary, "chart-uri: "+chartURI)
 			require.NotContains(t, reportSummary, "passed:")
 			require.NotContains(t, reportSummary, "failed:")
 		}
@@ -304,12 +302,12 @@ func loadChartFromAbsPath(path string) ([]byte, error) {
 	// Open the yaml file which defines the tests to run
 	reportFile, openErr := os.Open(path)
 	if openErr != nil {
-		return nil, errors.New(fmt.Sprintf("report path %s: error opening file  %v", path, openErr))
+		return nil, fmt.Errorf("report path %s: error opening file  %v", path, openErr)
 	}
 
-	reportBytes, readErr := ioutil.ReadAll(reportFile)
+	reportBytes, readErr := io.ReadAll(reportFile)
 	if readErr != nil {
-		return nil, errors.New(fmt.Sprintf("report path %s: error reading file  %v", path, readErr))
+		return nil, fmt.Errorf("report path %s: error reading file  %v", path, readErr)
 	}
 
 	return reportBytes, nil

--- a/pkg/chartverifier/reportsummary/reportsummary_test.go
+++ b/pkg/chartverifier/reportsummary/reportsummary_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAddStringReport(t *testing.T) {
-
 	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/report.yaml"
 	jsonFileReport := "test-reports/report.json"
@@ -33,11 +32,9 @@ func TestAddStringReport(t *testing.T) {
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
 	checkReportSummaries(reportSummary, chartUri, t)
-
 }
 
 func TestBadDigestReport(t *testing.T) {
-
 	yamlFileReport := "test-reports/baddigest/report.yaml"
 	jsonFileReport := "test-reports/baddigest/report.json"
 
@@ -57,11 +54,9 @@ func TestBadDigestReport(t *testing.T) {
 	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JsonReport)
 	require.Error(t, summaryErr)
 	require.Contains(t, fmt.Sprintf("%v", summaryErr), "digest in report did not match report content")
-
 }
 
 func TestSkipBadDigestReport(t *testing.T) {
-
 	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/baddigest/report.yaml"
 	jsonFileReport := "test-reports/baddigest/report.json"
@@ -83,7 +78,6 @@ func TestSkipBadDigestReport(t *testing.T) {
 }
 
 func TestMissingDigestReport(t *testing.T) {
-
 	yamlFileReport := "test-reports/missingdigest/report.yaml"
 	jsonFileReport := "test-reports/missingdigest/report.json"
 
@@ -103,11 +97,9 @@ func TestMissingDigestReport(t *testing.T) {
 	_, summaryErr = NewReportSummary().SetReport(report).GetContent(AllSummary, JsonReport)
 	require.Error(t, summaryErr)
 	require.Contains(t, fmt.Sprintf("%v", summaryErr), "Report does not contain expected report digest.")
-
 }
 
 func TestPreDigestReport(t *testing.T) {
-
 	chartUri := "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.9/psql-service-0.1.9.tgz?raw=true"
 	yamlFileReport := "test-reports/predigest/report.yaml"
 	jsonFileReport := "test-reports/predigest/report.json"
@@ -126,11 +118,9 @@ func TestPreDigestReport(t *testing.T) {
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
 	checkReportSummaries(reportSummary, chartUri, t)
-
 }
 
 func TestProviderDeliveryReport(t *testing.T) {
-
 	chartUri := "N/A"
 	yamlFileReport := "test-reports/providerdelivery/report.yaml"
 	jsonFileReport := "test-reports/providerdelivery/report.json"
@@ -149,11 +139,9 @@ func TestProviderDeliveryReport(t *testing.T) {
 	require.NoError(t, loadErr)
 	reportSummary = NewReportSummary().SetReport(report)
 	checkReportSummaries(reportSummary, chartUri, t)
-
 }
 
 func TestAddUrlReport(t *testing.T) {
-
 	yamlUrlReport := "https://github.com/redhat-certification/chart-verifier/blob/main/cmd/test/report.yaml?raw=true"
 	url, loadUrlErr := url.Parse(yamlUrlReport)
 	require.NoError(t, loadUrlErr)
@@ -164,7 +152,6 @@ func TestAddUrlReport(t *testing.T) {
 	reportSummary := NewReportSummary().SetReport(report)
 
 	checkReportSummaries(reportSummary, chartUri, t)
-
 }
 
 func checkReportSummaries(summary APIReportSummary, chartUri string, t *testing.T) {
@@ -173,7 +160,6 @@ func checkReportSummaries(summary APIReportSummary, chartUri string, t *testing.
 }
 
 func checkReportSummariesFormat(format SummaryFormat, summary APIReportSummary, chartUri string, t *testing.T) {
-
 	reportSummary, reportSummaryErr := summary.GetContent(AllSummary, format)
 	require.NoError(t, reportSummaryErr)
 	checkSummaryAll(format, reportSummary, chartUri, t)
@@ -193,7 +179,6 @@ func checkReportSummariesFormat(format SummaryFormat, summary APIReportSummary, 
 	reportSummary, reportSummaryErr = summary.GetContent(ResultsSummary, format)
 	require.NoError(t, reportSummaryErr)
 	checkSummaryResults(false, format, reportSummary, chartUri, t)
-
 }
 
 func checkSummaryAll(format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {
@@ -201,7 +186,6 @@ func checkSummaryAll(format SummaryFormat, reportSummary string, chartUri string
 	checkSummaryDigests(true, format, reportSummary, chartUri, t)
 	checkSummaryMetadata(true, format, reportSummary, chartUri, t)
 	checkSummaryResults(true, format, reportSummary, chartUri, t)
-
 }
 
 func checkSummaryResults(fullReport bool, format SummaryFormat, reportSummary string, chartUri string, t *testing.T) {

--- a/pkg/chartverifier/reportsummary/types.go
+++ b/pkg/chartverifier/reportsummary/types.go
@@ -6,9 +6,11 @@ import (
 	helmchart "helm.sh/helm/v3/pkg/chart"
 )
 
-type SummaryType string
-type SummaryFormat string
-type BooleanKey string
+type (
+	SummaryType   string
+	SummaryFormat string
+	BooleanKey    string
+)
 
 type ReportSummary struct {
 	options           *reportOptions

--- a/pkg/chartverifier/reportsummary/types.go
+++ b/pkg/chartverifier/reportsummary/types.go
@@ -1,9 +1,10 @@
 package reportsummary
 
 import (
+	helmchart "helm.sh/helm/v3/pkg/chart"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	apireport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
-	helmchart "helm.sh/helm/v3/pkg/chart"
 )
 
 type (
@@ -35,8 +36,10 @@ type MetadataReport struct {
 	ProfileVendorType profiles.VendorType `json:"vendorType" yaml:"vendorType"`
 	ProfileVersion    string              `json:"profileVersion" yaml:"profileVersion"`
 	WebCatalogOnly    bool                `json:"webCatalogOnly" yaml:"webCatalogOnly,omitempty"`
-	ChartUri          string              `json:"chart-uri" yaml:"chart-uri"`
-	Chart             *helmchart.Metadata `json:"chart" yaml:"chart"`
+	//nolint:stylecheck // complains Uri should be URI - leaving as is for now
+	//because this produces an outputted file.
+	ChartUri string              `json:"chart-uri" yaml:"chart-uri"`
+	Chart    *helmchart.Metadata `json:"chart" yaml:"chart"`
 }
 
 type ResultsReport struct {

--- a/pkg/chartverifier/samples/sample.go
+++ b/pkg/chartverifier/samples/sample.go
@@ -38,7 +38,7 @@ func runVerifier() error {
 	reportSummary, summmaryErr := reportsummary.NewReportSummary().
 		SetReport(verifier.GetReport()).
 		SetValues(values).
-		GetContent(reportsummary.AllSummary, reportsummary.JsonReport)
+		GetContent(reportsummary.AllSummary, reportsummary.JSONReport)
 
 	if summmaryErr != nil {
 		return summmaryErr

--- a/pkg/chartverifier/verifier/verifier_test.go
+++ b/pkg/chartverifier/verifier/verifier_test.go
@@ -186,8 +186,8 @@ func TestSignedChart(t *testing.T) {
 }
 
 func checkReportSummaries(summary apireportsummary.APIReportSummary, chartURI string, t *testing.T) {
-	checkReportSummariesFormat(apireportsummary.YamlReport, summary, chartURI, t)
-	checkReportSummariesFormat(apireportsummary.JsonReport, summary, chartURI, t)
+	checkReportSummariesFormat(apireportsummary.YAMLReport, summary, chartURI, t)
+	checkReportSummariesFormat(apireportsummary.JSONReport, summary, chartURI, t)
 }
 
 func checkReportSummariesFormat(format apireportsummary.SummaryFormat, summary apireportsummary.APIReportSummary, chartURI string, t *testing.T) {
@@ -220,7 +220,7 @@ func checkSummaryAll(format apireportsummary.SummaryFormat, reportSummary string
 }
 
 func checkSummaryResults(fullReport bool, format apireportsummary.SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
-	if format == apireportsummary.JsonReport {
+	if format == apireportsummary.JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"digests\":{")
@@ -247,7 +247,7 @@ func checkSummaryResults(fullReport bool, format apireportsummary.SummaryFormat,
 }
 
 func checkSummaryAnnotations(fullReport bool, format apireportsummary.SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
-	if format == apireportsummary.JsonReport {
+	if format == apireportsummary.JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"digests\":{")
 			require.NotContains(t, reportSummary, "\"metadata\":{")
@@ -275,7 +275,7 @@ func checkSummaryAnnotations(fullReport bool, format apireportsummary.SummaryFor
 }
 
 func checkSummaryMetadata(fullReport bool, format apireportsummary.SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
-	if format == apireportsummary.JsonReport {
+	if format == apireportsummary.JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"digests\":{")
@@ -302,7 +302,7 @@ func checkSummaryMetadata(fullReport bool, format apireportsummary.SummaryFormat
 }
 
 func checkSummaryDigests(fullReport bool, format apireportsummary.SummaryFormat, reportSummary string, chartURI string, t *testing.T) {
-	if format == apireportsummary.JsonReport {
+	if format == apireportsummary.JSONReport {
 		if !fullReport {
 			require.NotContains(t, reportSummary, "\"annotations\":[{")
 			require.NotContains(t, reportSummary, "\"metadata\":{")


### PR DESCRIPTION
Most of these are style checks for things like `Uri` to `URI`. Few nolints were handed out here.