### PR TITLE
Apply gofumpt to checks package

### DIFF
--- a/pkg/chartverifier/checks/checks.go
+++ b/pkg/chartverifier/checks/checks.go
@@ -19,7 +19,8 @@ const (
 	ExperimentalCheckType      CheckType = "Experimental"
 )
 
-var setCheckNames = []CheckName{ChartTesting,
+var setCheckNames = []CheckName{
+	ChartTesting,
 	ContainsTest,
 	ContainsValuesSchema,
 	ContainsValues,
@@ -31,7 +32,8 @@ var setCheckNames = []CheckName{ChartTesting,
 	NotContainCsiObjects,
 	NotContainsCRDs,
 	RequiredAnnotationsPresent,
-	SignatureIsValid}
+	SignatureIsValid,
+}
 
 func GetChecks() []CheckName {
 	return setCheckNames

--- a/pkg/chartverifier/checks/types.go
+++ b/pkg/chartverifier/checks/types.go
@@ -1,4 +1,6 @@
 package checks
 
-type CheckName string
-type CheckType string
+type (
+	CheckName string
+	CheckType string
+)


### PR DESCRIPTION
This package also had no golangci-lint hits, so only gofumpt is being applied here.