### PR TITLE
Remove the github.com/pkg/errors package in favor of the stdlib

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -65,7 +65,7 @@ func NewReportCmd(config *viper.Viper) *cobra.Command {
 			case string(apireportsummary.AllSummary):
 				reportType = apireportsummary.AllSummary
 			default:
-				return errors.New(fmt.Sprintf("Error: command %s not recognized", commandArg))
+				return fmt.Errorf("Error: command %s not recognized", commandArg)
 			}
 
 			valueMap := make(map[string]interface{})
@@ -85,12 +85,8 @@ func NewReportCmd(config *viper.Viper) *cobra.Command {
 			reportBytes, readErr := io.ReadAll(reportFile)
 			if readErr != nil {
 				//nolint:errcheck // TODO(komish): The linter indicates that we've not done anything with
-				// this error, which is correct. Perhaps the bigger issue is that this uses an archived API
-				// at https://github.com/pkg/errors. We should consider resolving both, as I'm not sure what we'd expect
-				// for this error (as in, where it should be presented). given that this logic just seems to wrap the input error.
-				//
-				// For now, ignoring the linter. https://github.com/redhat-certification/chart-verifier/issues/321
-				errors.New(fmt.Sprintf("report path %s: error reading file  %v", reportArg, readErr))
+				// this error, which is correct. Need to confirm what the intention was before changing this.
+				fmt.Errorf("report path %s: error reading file  %v", reportArg, readErr)
 			}
 
 			report, loadErr := apireport.NewReport().

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -32,8 +33,6 @@ import (
 	"helm.sh/helm/v3/pkg/cli/values"
 
 	//"helm.sh/helm/v3/pkg/getter"
-
-	"github.com/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -104,7 +103,7 @@ func convertChecks(checks []string) ([]apiChecks.CheckName, error) {
 			}
 		}
 		if !checkFound {
-			return apiCheckSet, errors.New(fmt.Sprintf("enabled check is invalid :%s", check))
+			return apiCheckSet, fmt.Errorf("enabled check is invalid :%s", check)
 		}
 	}
 	return apiCheckSet, nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/helm/chart-testing/v3 v3.4.0
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.7.2
@@ -113,6 +112,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -17,6 +17,7 @@
 package checks
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/sprig"
-	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/lint"

--- a/internal/chartverifier/checks/helm.go
+++ b/internal/chartverifier/checks/helm.go
@@ -18,6 +18,7 @@ package checks
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -32,7 +33,6 @@ import (
 
 	"helm.sh/helm/v3/pkg/chartutil"
 
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 
@@ -49,7 +49,7 @@ import (
 // doesn't contain the 'http' or 'https' schema, or any other error related to retrieving the contents of the chart.
 func loadChartFromRemote(url *url.URL) (*chart.Chart, error) {
 	if url.Scheme != "http" && url.Scheme != "https" {
-		return nil, errors.Errorf("only 'http' and 'https' schemes are supported, but got %q", url.Scheme)
+		return nil, fmt.Errorf("only 'http' and 'https' schemes are supported, but got %q", url.Scheme)
 	}
 
 	resp, err := http.Get(url.String())
@@ -169,7 +169,7 @@ func LoadChartFromURI(opts *CheckOptions) (*chart.Chart, string, error) {
 	case "file", "":
 		chrt, err = loadChartFromAbsPath(u.Path)
 	default:
-		return nil, "", errors.Errorf("scheme %q not supported", u.Scheme)
+		return nil, "", fmt.Errorf("scheme %q not supported", u.Scheme)
 	}
 
 	if err != nil {

--- a/internal/chartverifier/reportBuilder.go
+++ b/internal/chartverifier/reportBuilder.go
@@ -21,11 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
-	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,6 +28,11 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
+	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 
 	helmchart "helm.sh/helm/v3/pkg/chart"
 )
@@ -228,7 +228,7 @@ func GetPackageDigest(uri string) string {
 			chartReader, _ = os.Open(url.Path)
 		}
 	default:
-		err = errors.Errorf("scheme %q not supported", url.Scheme)
+		err = fmt.Errorf("scheme %q not supported", url.Scheme)
 	}
 	if err != nil || chartReader == nil {
 		return ""


### PR DESCRIPTION
This package solved problems not solved by the stdlib at the time, but it has been archived since 2021 and the stdlib now covers the use cases.

This PR replaces this package with the stdlib. The package still shows up as an indirect dependency because Helm appears to use the same one.

Fixes: #321 