### PR TITLE
Apply gofumpt and golangci-lint to internal/chartverifier

### DIFF
--- a/internal/chartverifier/api/verifier.go
+++ b/internal/chartverifier/api/verifier.go
@@ -1,10 +1,10 @@
 package api
 
 import (
+	"time"
+
 	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/cli"
-
-	"time"
 
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
@@ -36,7 +36,6 @@ type RunOptions struct {
 }
 
 func Run(options RunOptions) (*apireport.Report, error) {
-
 	var verifyReport *apireport.Report
 
 	verifierBuilder := chartverifier.NewVerifierBuilder()
@@ -68,7 +67,6 @@ func Run(options RunOptions) (*apireport.Report, error) {
 		SetSettings(options.Settings).
 		SetPublicKeys(options.PublicKeys).
 		Build()
-
 	if err != nil {
 		return verifyReport, err
 	}
@@ -80,5 +78,4 @@ func Run(options RunOptions) (*apireport.Report, error) {
 	}
 
 	return verifyReport, nil
-
 }

--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -65,7 +65,6 @@ func (e OpenShiftSemVerErr) Error() string {
 // buildChartTestingConfiguration computes the chart testing related
 // configuration from the given check options.
 func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
-
 	// cfg will be populated with options gathered from the input
 	// check options.
 	cfg := config.Configuration{
@@ -103,7 +102,6 @@ func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
 // functions used in this context were also ported from
 // chart-verifier.
 func ChartTesting(opts *CheckOptions) (Result, error) {
-
 	utils.LogInfo("Start chart install and test check")
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
@@ -254,7 +252,6 @@ func upgradeAndTestChart(
 	kubectl *tool.Kubectl,
 	configRelease string,
 ) chart.TestResult {
-
 	// result contains the test result; please notice that each values
 	// file in the chart's 'ci' folder will be installed and tested
 	// and the first failure makes the test fail.
@@ -338,7 +335,7 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cle
 
 	filename = path.Join(tempDir, "values.yaml")
 
-	err = ioutil.WriteFile(filename, objBytes, 0644)
+	err = ioutil.WriteFile(filename, objBytes, 0o644)
 	if err != nil {
 		return "", nil, fmt.Errorf("writing values file new contents: %w", err)
 	}
@@ -356,7 +353,6 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cle
 // In the case the given filename is an empty string, it indicates that only the valueOverrides contents will be
 // materialized into the temporary file to be merged by `helm` when processing the chart.
 func newTempValuesFileWithOverrides(filename string, valuesOverrides map[string]interface{}) (string, func(), error) {
-
 	var obj map[string]interface{}
 
 	if filename != "" {
@@ -393,7 +389,6 @@ func installAndTestChartRelease(
 	valuesOverrides map[string]interface{},
 	configRelease string,
 ) chart.TestResult {
-
 	// valuesFiles contains all the configurations that should be
 	// executed; in other words, it performs a test matrix between
 	// values files and tests.
@@ -411,7 +406,6 @@ func installAndTestChartRelease(
 		// Use anonymous function. Otherwise deferred calls would pile up
 		// and be executed in reverse order after the loop.
 		fun := func() error {
-
 			tmpValuesFile, tmpValuesFileCleanup, err := newTempValuesFileWithOverrides(valuesFile, valuesOverrides)
 			if err != nil {
 				// it is required this operation to succeed, otherwise there are no guarantees the values informed using

--- a/internal/chartverifier/checks/charttesting_test.go
+++ b/internal/chartverifier/checks/charttesting_test.go
@@ -164,9 +164,7 @@ func TestVersionSetting(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.description, func(t *testing.T) {
-
 			err := setOCVersion(tc.opts.AnnotationHolder, tc.opts.HelmEnvSettings, tc.versioner)
 
 			if len(tc.error) > 0 {
@@ -176,9 +174,6 @@ func TestVersionSetting(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.version, tc.opts.AnnotationHolder.(*testAnnotationHolder).OpenShiftVersion)
 			}
-
 		})
-
 	}
-
 }

--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -76,9 +76,7 @@ const (
 	RedHatRegistry               = "registry.redhat.io/"
 )
 
-var (
-	requiredAnnotations = [...]string{"charts.openshift.io/name"}
-)
+var requiredAnnotations = [...]string{"charts.openshift.io/name"}
 
 func notImplemented() (Result, error) {
 	return Result{Ok: false}, errors.New("not implemented")
@@ -130,7 +128,6 @@ func ContainsTest(opts *CheckOptions) (Result, error) {
 	}
 
 	return r, nil
-
 }
 
 func ContainsValues(opts *CheckOptions) (Result, error) {
@@ -190,7 +187,6 @@ func HasKubeVersion(opts *CheckOptions) (Result, error) {
 }
 
 func HasKubeVersion_V1_1(opts *CheckOptions) (Result, error) {
-
 	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
@@ -278,7 +274,6 @@ func CanBeInstalledWithoutClusterAdminPrivileges(opts *CheckOptions) (Result, er
 }
 
 func ImagesAreCertified(opts *CheckOptions) (Result, error) {
-
 	r := NewResult(true, "")
 
 	r = certifyImages(r, opts, "")
@@ -287,7 +282,6 @@ func ImagesAreCertified(opts *CheckOptions) (Result, error) {
 }
 
 func ImagesAreCertified_V1_1(opts *CheckOptions) (Result, error) {
-
 	r := NewResult(true, "")
 
 	r = certifyImages(r, opts, RedHatRegistry)
@@ -321,7 +315,6 @@ func RequiredAnnotationsPresent(opts *CheckOptions) (Result, error) {
 }
 
 func SignatureIsValid(opts *CheckOptions) (Result, error) {
-
 	chartPath := opts.URI
 
 	chartUrl, err := url.Parse(chartPath)
@@ -402,11 +395,9 @@ func SignatureIsValid(opts *CheckOptions) (Result, error) {
 	}
 
 	return NewResult(true, fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess)), nil
-
 }
 
 func parseImageReference(image string) pyxis.ImageReference {
-
 	imageRef := pyxis.ImageReference{}
 	imageParts := strings.Split(image, "/")
 
@@ -434,11 +425,9 @@ func parseImageReference(image string) pyxis.ImageReference {
 	}
 
 	return imageRef
-
 }
 
 func getOCPRange(kubeVersionRange string) (string, error) {
-
 	semverCompare := sprig.GenericFuncMap()["semverCompare"].(func(string, string) (bool, error))
 	minOCPVersion := ""
 	maxOCPVersion := ""
@@ -473,11 +462,9 @@ func getOCPRange(kubeVersionRange string) (string, error) {
 	}
 
 	return "", fmt.Errorf("%s : Failed to determine a minimum OCP version", KuberVersionProcessingError)
-
 }
 
 func downloadFile(fileURL *url.URL, directory string) (string, error) {
-
 	urlPath := fileURL.Path
 	segments := strings.Split(urlPath, "/")
 	fileName := segments[len(segments)-1]
@@ -514,7 +501,6 @@ func downloadFile(fileURL *url.URL, directory string) (string, error) {
 }
 
 func certifyImages(r Result, opts *CheckOptions, registry string) Result {
-
 	kubeVersion := ""
 	kubeConfig := tool.GetClientConfig(opts.HelmEnvSettings)
 	kubectl, kubeErr := tool.NewKubectl(kubeConfig)
@@ -548,7 +534,6 @@ func certifyImages(r Result, opts *CheckOptions, registry string) Result {
 			} else {
 				certified, checkImageErr := pyxis.IsImageInRegistry(imageRef)
 				if !certified {
-
 					if strings.Contains(checkImageErr.Error(), "No images found for Registry/Repository") && registry != "" {
 						if strings.HasPrefix(image, registry) {
 							r.SetSkipped(fmt.Sprintf("%s : %s", ImageCertifySkipped, image))

--- a/internal/chartverifier/checks/checks_test.go
+++ b/internal/chartverifier/checks/checks_test.go
@@ -250,7 +250,6 @@ func TestHasMinKubeVersion(t *testing.T) {
 			require.Equal(t, KuberVersionNotSpecified, r.Reason)
 		})
 	}
-
 }
 
 func TestNotContainCRDs(t *testing.T) {
@@ -364,19 +363,15 @@ func TestHelmLint(t *testing.T) {
 			require.Contains(t, r.Reason, HelmLintHasFailedPrefix)
 		})
 	}
-
 }
 
 func TestImageCertify(t *testing.T) {
-
 	checkImages(t, ImagesAreCertified, false)
 
 	checkImages(t, ImagesAreCertified_V1_1, true)
-
 }
 
 func checkImages(t *testing.T, fn func(*CheckOptions) (Result, error), version1_1 bool) {
-
 	type testCase struct {
 		description string
 		uri         string
@@ -439,7 +434,6 @@ func checkImages(t *testing.T, fn func(*CheckOptions) (Result, error), version1_
 }
 
 func TestImageParsing(t *testing.T) {
-
 	type testCase struct {
 		description      string
 		image            string
@@ -506,7 +500,6 @@ func TestRequiredAnnotationsPresent(t *testing.T) {
 }
 
 func TestSemVers(t *testing.T) {
-
 	// Vault: kubeVersion: '>= 1.14.0-0'
 	// IBM: kubeversion: '>=1.10.1-0'
 	// Fortanix : kubeversion: '>= 1.16.0 < 1.22.0'
@@ -547,7 +540,6 @@ func TestSemVers(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestSignatureIsValid(t *testing.T) {
@@ -561,36 +553,41 @@ func TestSignatureIsValid(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{description: "unsigned chart",
-			uri:     "chart-0.1.0-v3.no-missing-annotations.tgz",
-			keyFile: "",
-			reason:  fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
-			ok:      true, skipped: true,
+		{
+			description: "unsigned chart",
+			uri:         "chart-0.1.0-v3.no-missing-annotations.tgz",
+			keyFile:     "",
+			reason:      fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
+			ok:          true, skipped: true,
 		},
-		{description: "unsigned chart with key provided",
-			uri:     "chart-0.1.0-v3.no-missing-annotations.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
-			reason:  fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
-			ok:      true, skipped: true,
+		{
+			description: "unsigned chart with key provided",
+			uri:         "chart-0.1.0-v3.no-missing-annotations.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
+			reason:      fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
+			ok:          true, skipped: true,
 		},
 
-		{description: "signed chart with valid key",
-			uri:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess),
-			ok:      true, skipped: false,
+		{
+			description: "signed chart with valid key",
+			uri:         "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess),
+			ok:          true, skipped: false,
 		},
-		{description: "signed chart with no key",
-			uri:     "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz?raw=true",
-			keyFile: "",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureNoKey),
-			ok:      true, skipped: true,
+		{
+			description: "signed chart with no key",
+			uri:         "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz?raw=true",
+			keyFile:     "",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureNoKey),
+			ok:          true, skipped: true,
 		},
-		{description: "signed chart with bad key",
-			uri:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.badkey",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureFailure),
-			ok:      false, skipped: false,
+		{
+			description: "signed chart with bad key",
+			uri:         "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.badkey",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureFailure),
+			ok:          false, skipped: false,
 		},
 	}
 
@@ -611,5 +608,4 @@ func TestSignatureIsValid(t *testing.T) {
 			require.Contains(t, r.Reason, tc.reason, fmt.Sprintf("%s : reason mismatch", tc.description))
 		})
 	}
-
 }

--- a/internal/chartverifier/checks/helm.go
+++ b/internal/chartverifier/checks/helm.go
@@ -195,7 +195,6 @@ func IsChartNotFound(err error) bool {
 }
 
 func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersionString string) ([]string, error) {
-
 	capabilities := chartutil.DefaultCapabilities
 
 	if kubeVersionString == "" {
@@ -224,11 +223,9 @@ func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersio
 	}
 
 	return getImagesFromContent(txt)
-
 }
 
 func getImagesFromContent(content string) ([]string, error) {
-
 	imagesMap := make(map[string]bool)
 
 	type ImageRef struct {
@@ -259,7 +256,6 @@ func getImagesFromContent(content string) ([]string, error) {
 	}
 
 	return images, err
-
 }
 
 func getNextLine(reader *bufio.Reader) (string, error) {
@@ -284,5 +280,4 @@ func getCacheDir(opts *CheckOptions) string {
 		}
 	}
 	return path.Join(cacheDir, "chart-verifier")
-
 }

--- a/internal/chartverifier/checks/helm_test.go
+++ b/internal/chartverifier/checks/helm_test.go
@@ -147,7 +147,6 @@ func TestLoadChartFromURI(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-
 	type testCase struct {
 		description string
 		uri         string
@@ -155,10 +154,12 @@ func TestTemplate(t *testing.T) {
 	}
 
 	TestCases := []testCase{
-		{description: "chart-0.1.0-v3.valid.tgz images ", uri: "chart-0.1.0-v3.valid.tgz", images: []string{"registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest",
+		{description: "chart-0.1.0-v3.valid.tgz images ", uri: "chart-0.1.0-v3.valid.tgz", images: []string{
+			"registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest",
 			"snyk/kubernetes-operator", "rhscl/mongodb-36-rhel7:1-65",
 			"icr.io/cpopen/ibmcloud-object-storage-driver@sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f",
-			"icr.io/cpopen/ibmcloud-object-storage-plugin@sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}},
+			"icr.io/cpopen/ibmcloud-object-storage-plugin@sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e",
+		}},
 		{description: "chart-0.1.0-v3.with-crd.tgz", uri: "chart-0.1.0-v3.with-crd.tgz", images: []string{"nginx:1.16.0", "busybox"}},
 		{description: "chart-0.1.0-v3.with-csi.tgz", uri: "chart-0.1.0-v3.with-csi.tgz", images: []string{"nginx:1.16.0"}},
 	}
@@ -176,7 +177,6 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestLongLineTemplate(t *testing.T) {
-
 	content, err := ioutil.ReadFile("templates/test-template.yaml")
 	require.NoError(t, err)
 
@@ -187,5 +187,4 @@ func TestLongLineTemplate(t *testing.T) {
 
 	require.Contains(t, images, "1.1.1/cv-test/image1:tag-123")
 	require.Contains(t, images, "1.1.2/cv-test/image2:tag-223")
-
 }

--- a/internal/chartverifier/checks/registry.go
+++ b/internal/chartverifier/checks/registry.go
@@ -138,7 +138,6 @@ func (r *DefaultRegistry) Get(id CheckId) (Check, bool) {
 }
 
 func (r *DefaultRegistry) Add(name apiChecks.CheckName, version string, checkFunc CheckFunc) Registry {
-
 	check := Check{CheckId: CheckId{Name: name, Version: version}, Func: checkFunc}
 	(*r)[check.CheckId] = check
 	return r

--- a/internal/chartverifier/helmverifier.go
+++ b/internal/chartverifier/helmverifier.go
@@ -17,11 +17,12 @@
 package chartverifier
 
 import (
+	"time"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/cli"
-	"time"
 )
 
 type VerifierBuilder interface {

--- a/internal/chartverifier/helmverifier.go
+++ b/internal/chartverifier/helmverifier.go
@@ -19,10 +19,11 @@ package chartverifier
 import (
 	"time"
 
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
-	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/cli"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
+	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 )
 
 type VerifierBuilder interface {

--- a/internal/chartverifier/profiles/profile.go
+++ b/internal/chartverifier/profiles/profile.go
@@ -2,19 +2,22 @@ package profiles
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
 	"github.com/redhat-certification/chart-verifier/internal/profileconfig"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
-	"regexp"
-	"strings"
 )
 
-type Annotation string
-type VendorType string
-type VendorVersion string
+type (
+	Annotation    string
+	VendorType    string
+	VendorVersion string
+)
 
 const (
 	DigestAnnotation                 Annotation = "Digest"
@@ -69,7 +72,6 @@ func Get() *Profile {
 }
 
 func New(values map[string]interface{}) *Profile {
-
 	profileVendorType := VendorTypeDefault
 	var profileVersion string
 
@@ -113,7 +115,6 @@ func New(values map[string]interface{}) *Profile {
 
 // Get all profiles in the profiles directory, and any subdirectories, and add each to the profile map
 func getProfiles() {
-
 	profileFiles, err := profileconfig.GetProfiles()
 	if err != nil {
 		return
@@ -137,7 +138,6 @@ func getProfiles() {
 }
 
 func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRegistry {
-
 	filteredChecks := make(map[apiChecks.CheckName]checks.Check)
 
 	for _, check := range profile.Checks {
@@ -151,11 +151,9 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 	}
 
 	return filteredChecks
-
 }
 
 func readProfile(profileBytes []byte) (*Profile, error) {
-
 	profile := &Profile{}
 	err := yaml.Unmarshal(profileBytes, profile)
 	if err != nil {
@@ -163,5 +161,4 @@ func readProfile(profileBytes []byte) (*Profile, error) {
 	}
 
 	return profile, nil
-
 }

--- a/internal/chartverifier/profiles/profile_test.go
+++ b/internal/chartverifier/profiles/profile_test.go
@@ -29,7 +29,6 @@ const (
 )
 
 func TestProfile(t *testing.T) {
-
 	testProfile := getDefaultProfile("test")
 	testProfile.Name = "profile-partner-1.2"
 	config := make(map[string]interface{})
@@ -68,11 +67,9 @@ func TestProfile(t *testing.T) {
 			assert.True(t, cmp.Equal(diskProfile, testProfile), "profiles do not match")
 		}
 	})
-
 }
 
 func TestGetProfiles(t *testing.T) {
-
 	getAndCheckProfile(t, PartnerVendorType, PartnerVendorType, configVersion11, configVersion11)
 	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, configVersion11, configVersion11)
 	getAndCheckProfile(t, CommunityVendorType, CommunityVendorType, configVersion11, configVersion11)
@@ -88,7 +85,6 @@ func TestGetProfiles(t *testing.T) {
 }
 
 func getAndCheckProfile(t *testing.T, configVendorType, expectVendorType VendorType, configVersion, expectVersion string) {
-
 	config := make(map[string]interface{})
 
 	if len(configVendorType) > 0 {
@@ -105,11 +101,10 @@ func getAndCheckProfile(t *testing.T, configVendorType, expectVendorType VendorT
 		profile = Get()
 		assert.Equal(t, expectVendorType, profile.Vendor, "VendorType did not match")
 		assert.Equal(t, expectVersion, profile.Version, "Version did not match")
-
 	})
 }
-func TestProfileFilter(t *testing.T) {
 
+func TestProfileFilter(t *testing.T) {
 	defaultRegistry := checks.NewRegistry()
 
 	defaultRegistry.Add(apiChecks.HasReadme, checkVersion10, checks.HasReadme)
@@ -167,11 +162,9 @@ func TestProfileFilter(t *testing.T) {
 		filteredChecks := New(config).FilterChecks(defaultRegistry.AllChecks())
 		CompareCheckMaps(t, expectedChecks, filteredChecks)
 	})
-
 }
 
 func CompareCheckMaps(t *testing.T, expectedChecks, filteredChecks FilteredRegistry) {
-
 	assert.Equal(t, len(expectedChecks), len(filteredChecks), fmt.Sprintf("Expected map length : %d does not match returned mao length : %d", len(expectedChecks), len(filteredChecks)))
 	for k, v := range filteredChecks {
 		_, ok := expectedChecks[k]

--- a/internal/chartverifier/pyxis/pyxis.go
+++ b/internal/chartverifier/pyxis/pyxis.go
@@ -134,7 +134,6 @@ func GetImageRegistries(repository string) ([]string, error) {
 }
 
 func IsImageInRegistry(imageRef ImageReference) (bool, error) {
-
 	var err error
 	found := false
 

--- a/internal/chartverifier/pyxis/pyxis_test.go
+++ b/internal/chartverifier/pyxis/pyxis_test.go
@@ -17,12 +17,12 @@
 package pyxis
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getImageRegistries(t *testing.T) {
-
 	type testCase struct {
 		description string
 		repository  string
@@ -36,7 +36,8 @@ func Test_getImageRegistries(t *testing.T) {
 		{description: "Test rhel8/nginx-116 respository", repository: "rhel8/nginx-116", registry: "registry.access.redhat.com", message: ""},
 		{description: "Test ibm/nginx respository", repository: "ibm/nginx", registry: "non_registry", message: ""},
 		{description: "Test turbonomic/zookeeper respository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""}}
+		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""},
+	}
 
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -58,11 +59,9 @@ func Test_getImageRegistries(t *testing.T) {
 			require.Contains(t, err.Error(), tc.message)
 		})
 	}
-
 }
 
 func Test_checkImageInRegistry(t *testing.T) {
-
 	type testCase struct {
 		description string
 		message     string

--- a/internal/chartverifier/report.go
+++ b/internal/chartverifier/report.go
@@ -18,13 +18,16 @@ package chartverifier
 
 import (
 	"fmt"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 )
 
-var ReportApiVersion = "v1"
-var ReportKind = "verify-report"
+var (
+	ReportApiVersion = "v1"
+	ReportKind       = "verify-report"
+)
 
 type InternalReport struct {
 	APIReport apiReport.Report
@@ -73,11 +76,9 @@ func (cr *InternalCheckReport) GetApiCheckReport() *apiReport.CheckReport {
 }
 
 func (ir *InternalReport) SetReportDigest() {
-
 	var err error
 	ir.APIReport.Metadata.ToolMetadata.ReportDigest, err = ir.APIReport.GetReportDigest()
 	if err != nil {
 		ir.APIReport.Metadata.ToolMetadata.ReportDigest = err.Error()
 	}
-
 }

--- a/internal/chartverifier/report.go
+++ b/internal/chartverifier/report.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	ReportApiVersion = "v1"
+	ReportAPIVersion = "v1"
 	ReportKind       = "verify-report"
 )
 
@@ -39,7 +39,7 @@ type InternalCheckReport struct {
 
 func newReport() InternalReport {
 	report := InternalReport{}
-	report.APIReport = apiReport.Report{Apiversion: ReportApiVersion, Kind: ReportKind}
+	report.APIReport = apiReport.Report{Apiversion: ReportAPIVersion, Kind: ReportKind}
 	report.APIReport.Metadata = apiReport.ReportMetadata{}
 	report.APIReport.Metadata.ToolMetadata = apiReport.ToolMetadata{}
 
@@ -50,6 +50,8 @@ func (ir *InternalReport) AddCheck(check checks.Check) *InternalCheckReport {
 	newCheck := InternalCheckReport{}
 	newCheck.APICheckReport = apiReport.CheckReport{}
 	newCheck.APICheckReport.Check = apiChecks.CheckName(fmt.Sprintf("%s/%s", check.CheckId.Version, check.CheckId.Name))
+	//nolint:unconvert // TODO(komish): The assertion here goes from api checks to internal check types.
+	// Need to research the key differences in the two implementations before we remove this assertion.
 	newCheck.APICheckReport.Type = apiChecks.CheckType(check.Type)
 	newCheck.APICheckReport.Outcome = apiReport.UnknownOutcomeType
 	ir.APIReport.Results = append(ir.APIReport.Results, &newCheck.APICheckReport)
@@ -67,11 +69,11 @@ func (cr *InternalCheckReport) SetResult(outcome bool, skipped bool, reason stri
 	cr.APICheckReport.Reason = reason
 }
 
-func (ir *InternalReport) GetApiReport() *apiReport.Report {
+func (ir *InternalReport) GetAPIReport() *apiReport.Report {
 	return &ir.APIReport
 }
 
-func (cr *InternalCheckReport) GetApiCheckReport() *apiReport.CheckReport {
+func (cr *InternalCheckReport) GetAPICheckReport() *apiReport.CheckReport {
 	return &cr.APICheckReport
 }
 

--- a/internal/chartverifier/reportBuilder.go
+++ b/internal/chartverifier/reportBuilder.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
@@ -41,7 +42,7 @@ import (
 type ReportBuilder interface {
 	SetToolVersion(name string) ReportBuilder
 	SetProfile(vendorType profiles.VendorType, version string) ReportBuilder
-	SetChartUri(name string) ReportBuilder
+	SetChartURI(name string) ReportBuilder
 	AddCheck(check checks.Check, result checks.Result) ReportBuilder
 	SetChart(chart *helmchart.Chart) ReportBuilder
 	SetTestedOpenShiftVersion(version string) ReportBuilder
@@ -81,34 +82,34 @@ func (r *reportBuilder) SetSupportedOpenShiftVersions(versions string) ReportBui
 }
 
 func (r *reportBuilder) SetToolVersion(version string) ReportBuilder {
-	r.Report.GetApiReport().Metadata.ToolMetadata.Version = version
+	r.Report.GetAPIReport().Metadata.ToolMetadata.Version = version
 	return r
 }
 
 func (r *reportBuilder) SetProfile(vendorType profiles.VendorType, version string) ReportBuilder {
-	r.Report.GetApiReport().Metadata.ToolMetadata.Profile.VendorType = string(vendorType)
-	r.Report.GetApiReport().Metadata.ToolMetadata.Profile.Version = version
+	r.Report.GetAPIReport().Metadata.ToolMetadata.Profile.VendorType = string(vendorType)
+	r.Report.GetAPIReport().Metadata.ToolMetadata.Profile.Version = version
 	return r
 }
 
-func (r *reportBuilder) SetChartUri(uri string) ReportBuilder {
-	r.Report.GetApiReport().Metadata.ToolMetadata.ChartUri = uri
+func (r *reportBuilder) SetChartURI(uri string) ReportBuilder {
+	r.Report.GetAPIReport().Metadata.ToolMetadata.ChartUri = uri
 	return r
 }
 
 func (r *reportBuilder) SetChart(chart *helmchart.Chart) ReportBuilder {
 	r.Chart = chart
-	r.Report.GetApiReport().Metadata.ChartData = chart.Metadata
+	r.Report.GetAPIReport().Metadata.ChartData = chart.Metadata
 	return r
 }
 
 func (r *reportBuilder) SetWebCatalogOnly(webCatalogOnly bool) ReportBuilder {
-	r.Report.GetApiReport().Metadata.ToolMetadata.WebCatalogOnly = webCatalogOnly
+	r.Report.GetAPIReport().Metadata.ToolMetadata.WebCatalogOnly = webCatalogOnly
 	return r
 }
 
 func (r *reportBuilder) SetPublicKeyDigest(digest string) ReportBuilder {
-	r.Report.GetApiReport().Metadata.ToolMetadata.Digests.PublicKey = digest
+	r.Report.GetAPIReport().Metadata.ToolMetadata.Digests.PublicKey = digest
 	return r
 }
 
@@ -123,7 +124,7 @@ func (r *reportBuilder) AddCheck(check checks.Check, result checks.Result) Repor
 }
 
 func (r *reportBuilder) Build() (*apiReport.Report, error) {
-	apiReport := r.Report.GetApiReport()
+	apiReport := r.Report.GetAPIReport()
 
 	for _, annotation := range profiles.Get().Annotations {
 		switch annotation {
@@ -155,7 +156,7 @@ func (r *reportBuilder) Build() (*apiReport.Report, error) {
 	apiReport.Metadata.ToolMetadata.Digests.Package = GetPackageDigest(apiReport.Metadata.ToolMetadata.ChartUri)
 
 	if apiReport.Metadata.ToolMetadata.WebCatalogOnly {
-		r.SetChartUri(("N/A"))
+		r.SetChartURI(("N/A"))
 	}
 
 	r.Report.SetReportDigest()

--- a/internal/chartverifier/reportBuilder.go
+++ b/internal/chartverifier/reportBuilder.go
@@ -21,11 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
-	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 	"io"
 	"net/http"
 	"net/url"
@@ -33,6 +28,12 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
+	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
 
 	helmchart "helm.sh/helm/v3/pkg/chart"
 )
@@ -122,7 +123,6 @@ func (r *reportBuilder) AddCheck(check checks.Check, result checks.Result) Repor
 }
 
 func (r *reportBuilder) Build() (*apiReport.Report, error) {
-
 	apiReport := r.Report.GetApiReport()
 
 	for _, annotation := range profiles.Get().Annotations {
@@ -194,7 +194,6 @@ func (fs *fileSorter) Less(i, j int) bool {
 }
 
 func GenerateSha(rawFiles []*helmchart.File) string {
-
 	name := func(f1, f2 *helmchart.File) bool {
 		return f1.Name < f2.Name
 	}
@@ -210,7 +209,6 @@ func GenerateSha(rawFiles []*helmchart.File) string {
 }
 
 func GetPackageDigest(uri string) string {
-
 	url, err := url.Parse(uri)
 	if err != nil {
 		return ""

--- a/internal/chartverifier/reportbuilder_test.go
+++ b/internal/chartverifier/reportbuilder_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/cli"
 
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 )
 
 func TestSha(t *testing.T) {

--- a/internal/chartverifier/reportbuilder_test.go
+++ b/internal/chartverifier/reportbuilder_test.go
@@ -16,12 +16,13 @@ import (
 )
 
 func TestSha(t *testing.T) {
-
-	charts := []string{"checks/chart-0.1.0-v3.with-csi.tgz",
+	charts := []string{
+		"checks/chart-0.1.0-v3.with-csi.tgz",
 		"checks/chart-0.1.0-v3.valid.tgz",
 		"checks/chart-0.1.0-v2.invalid.tgz",
 		"checks/chart-0.1.0-v3.without-readme.tgz",
-		"checks/chart-0.1.0-v3.with-crd.tgz"}
+		"checks/chart-0.1.0-v3.with-crd.tgz",
+	}
 
 	shas := make(map[string]string)
 
@@ -44,7 +45,6 @@ func TestSha(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// get sha's again and make sure they match
 		for _, chart := range charts {
-
 			t.Run("Sha must not change : "+chart, func(t *testing.T) {
 				opts := checks.CheckOptions{
 					URI:             chart,
@@ -59,16 +59,16 @@ func TestSha(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func TestFilePackageDigest(t *testing.T) {
-
-	charts := []string{"checks/chart-0.1.0-v3.with-csi.tgz",
+	charts := []string{
+		"checks/chart-0.1.0-v3.with-csi.tgz",
 		"checks/chart-0.1.0-v3.valid.tgz",
 		"checks/chart-0.1.0-v2.invalid.tgz",
 		"checks/chart-0.1.0-v3.without-readme.tgz",
-		"checks/chart-0.1.0-v3.with-crd.tgz"}
+		"checks/chart-0.1.0-v3.with-crd.tgz",
+	}
 
 	for _, chart := range charts {
 		cmd := exec.Command("sha256sum", chart)
@@ -79,11 +79,9 @@ func TestFilePackageDigest(t *testing.T) {
 		commandResponse := strings.Split(out.String(), " ")
 		assert.Equal(t, commandResponse[0], GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
 	}
-
 }
 
 func TestUrlPackageDigest(t *testing.T) {
-
 	charts := make(map[string]string)
 
 	charts["https://github.com/openshift-helm-charts/charts/releases/download/hashicorp-vault-0.13.0/hashicorp-vault-0.13.0.tgz"] = "97e274069d9d3d028903610a3f9fca892b2620f0a334de6215ec5f962328586f"
@@ -92,9 +90,6 @@ func TestUrlPackageDigest(t *testing.T) {
 	charts["checks/chart-0.1.0-v3.valid.tgz?raw=true"] = "577c5bbc52f405da1b494bbf1b8251f8e6fdc316583bb0ee71eb74baed843615"
 
 	for chart, sha := range charts {
-
 		assert.Equal(t, sha, GetPackageDigest(chart), fmt.Sprintf("%s digests did not match as expected", chart))
-
 	}
-
 }

--- a/internal/chartverifier/utils/logger.go
+++ b/internal/chartverifier/utils/logger.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -15,6 +13,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type VerifierLog struct {
@@ -27,13 +28,17 @@ type LogEntry struct {
 	Entry string `json:"Entry" yaml:"Entry"`
 }
 
-var CmdStdout io.Writer = os.Stdout
-var CmdStderr io.Writer = os.Stderr
+var (
+	CmdStdout io.Writer = os.Stdout
+	CmdStderr io.Writer = os.Stderr
+)
 
-var verifierlog VerifierLog
-var cmd *cobra.Command
-var stdoutFileName string
-var stderrFileName string
+var (
+	verifierlog    VerifierLog
+	cmd            *cobra.Command
+	stdoutFileName string
+	stderrFileName string
+)
 
 const outputDirectory string = "chartverifier"
 
@@ -72,7 +77,6 @@ func LogError(message string) {
 }
 
 func WriteLogs(log_format string) {
-
 	pruneLogFiles()
 
 	if len(verifierlog.Entries) > 0 && len(stderrFileName) > 0 {
@@ -95,7 +99,6 @@ func WriteLogs(log_format string) {
 		writeToFile(logOut, stderrFileName)
 	}
 	return
-
 }
 
 func WriteStdOut(output string) {
@@ -116,7 +119,6 @@ func writeToStdOut(output string) {
 }
 
 func writeToFile(output string, fileName string) bool {
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
@@ -126,7 +128,7 @@ func writeToFile(output string, fileName string) bool {
 	outputFile := path.Join(outputDir, fileName)
 	if _, err := os.Stat(outputDir); err != nil {
 		// #nosec G301
-		if err = os.MkdirAll(outputDir, 0777); err != nil {
+		if err = os.MkdirAll(outputDir, 0o777); err != nil {
 			LogError(fmt.Sprintf("error creating directory : %s : %s", outputDir, err))
 			return false
 		}
@@ -140,7 +142,7 @@ func writeToFile(output string, fileName string) bool {
 		LogError(fmt.Sprintf("Error removing existing file %s: %s", fileName, err))
 	}
 	// #nosec G304
-	if outfile, open_err := os.OpenFile(outputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600); open_err == nil {
+	if outfile, open_err := os.OpenFile(outputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600); open_err == nil {
 		outfile.WriteString(output)
 		outfile.Close()
 		return true
@@ -181,7 +183,6 @@ func (fs *fileSorter) Less(i, j int) bool {
 }
 
 func pruneLogFiles() {
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
@@ -221,7 +222,6 @@ func pruneLogFiles() {
 		}
 
 	}
-
 }
 
 func getTimeStamp() string {

--- a/internal/chartverifier/utils/logger_test.go
+++ b/internal/chartverifier/utils/logger_test.go
@@ -3,15 +3,16 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 )
 
 func NewTestCmd(config *viper.Viper) *cobra.Command {
@@ -51,7 +52,6 @@ func NewTestCmd(config *viper.Viper) *cobra.Command {
 }
 
 func TestLogging(t *testing.T) {
-
 	t.Run("LogInfo, no logfile, should be no output", func(t *testing.T) {
 		tCmd := NewTestCmd(viper.New())
 		outBuf := bytes.NewBufferString("")
@@ -63,7 +63,6 @@ func TestLogging(t *testing.T) {
 
 		require.Empty(t, outBuf.String())
 		require.Empty(t, errBuf.String())
-
 	})
 
 	t.Run("LogInfo, set logfile, should be a logfile created", func(t *testing.T) {
@@ -85,7 +84,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Write to stdOut to a file", func(t *testing.T) {
@@ -105,7 +103,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure report is deleted")
 		})
-
 	})
 
 	t.Run("Write Error to stdError and file", func(t *testing.T) {
@@ -125,7 +122,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Write Warning to stdError and file", func(t *testing.T) {
@@ -145,7 +141,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Test log file pruning", func(t *testing.T) {
@@ -170,7 +165,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log file are deleted")
 		})
-
 	})
 }
 

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -86,7 +86,6 @@ func (c *verifier) subConfig(name string) *viper.Viper {
 }
 
 func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
-
 	if c.webCatalogOnly {
 		if len(GetPackageDigest(uri)) == 0 {
 			return nil, CheckErr("Provider delivery control requires chart input which is a tarball.")
@@ -110,8 +109,10 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 		if check.Func == nil {
 			return nil, CheckNotFoundErr(check.CheckId.Name)
 		}
-		holder := AnnotationHolder{Holder: result,
-			CertifiedOpenShiftVersionFlag: c.openshiftVersion}
+		holder := AnnotationHolder{
+			Holder:                        result,
+			CertifiedOpenShiftVersionFlag: c.openshiftVersion,
+		}
 
 		r, checkErr := check.Func(&checks.CheckOptions{
 			HelmEnvSettings:    c.settings,

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -20,13 +20,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
+	helmcli "helm.sh/helm/v3/pkg/cli"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"github.com/redhat-certification/chart-verifier/internal/tool"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
-	"github.com/spf13/viper"
-	helmcli "helm.sh/helm/v3/pkg/cli"
 )
 
 type CheckNotFoundErr string
@@ -99,13 +100,12 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 
 	result := NewReportBuilder().
 		SetToolVersion(c.toolVersion).
-		SetChartUri(uri).
+		SetChartURI(uri).
 		SetChart(chrt).
 		SetProfile(c.profile.Vendor, c.profile.Version).
 		SetWebCatalogOnly(c.webCatalogOnly)
 
 	for _, check := range c.requiredChecks {
-
 		if check.Func == nil {
 			return nil, CheckNotFoundErr(check.CheckId.Name)
 		}

--- a/internal/chartverifier/verifier_test.go
+++ b/internal/chartverifier/verifier_test.go
@@ -63,7 +63,7 @@ func TestVerifier_Verify(t *testing.T) {
 		return checks.Result{Ok: true}, nil
 	}
 
-	validChartUri := "http://" + addr + "/charts/chart-0.1.0-v3.valid.tgz"
+	validChartURI := "http://" + addr + "/charts/chart-0.1.0-v3.valid.tgz"
 
 	t.Run("Should return error if check does not exist", func(t *testing.T) {
 		c := &verifier{
@@ -74,7 +74,7 @@ func TestVerifier_Verify(t *testing.T) {
 			requiredChecks: []checks.Check{dummyCheck},
 		}
 
-		r, err := c.Verify(validChartUri)
+		r, err := c.Verify(validChartURI)
 		require.Error(t, err)
 		require.Nil(t, r)
 	})
@@ -89,7 +89,7 @@ func TestVerifier_Verify(t *testing.T) {
 			requiredChecks: []checks.Check{dummyCheck},
 		}
 
-		r, err := c.Verify(validChartUri)
+		r, err := c.Verify(validChartURI)
 		require.Error(t, err)
 		require.Nil(t, r)
 	})
@@ -105,7 +105,7 @@ func TestVerifier_Verify(t *testing.T) {
 			openshiftVersion: "4.9",
 		}
 
-		r, err := c.Verify(validChartUri)
+		r, err := c.Verify(validChartURI)
 		require.NoError(t, err)
 		require.NotNil(t, r)
 		require.False(t, isOk(r))
@@ -122,7 +122,7 @@ func TestVerifier_Verify(t *testing.T) {
 			webCatalogOnly: true,
 		}
 
-		r, err := c.Verify(validChartUri)
+		r, err := c.Verify(validChartURI)
 		require.NoError(t, err)
 		require.NotNil(t, r)
 		require.True(t, isOk(r))

--- a/internal/chartverifier/verifier_test.go
+++ b/internal/chartverifier/verifier_test.go
@@ -19,8 +19,9 @@ package chartverifier
 import (
 	"context"
 	"errors"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"testing"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,6 @@ func isOk(c *apiReport.Report) bool {
 }
 
 func TestVerifier_Verify(t *testing.T) {
-
 	addr := "127.0.0.1:9876"
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/chartverifier/verifierbuilder.go
+++ b/internal/chartverifier/verifierbuilder.go
@@ -99,7 +99,6 @@ func (b *verifierBuilder) SetConfig(config *viper.Viper) VerifierBuilder {
 }
 
 func (b *verifierBuilder) SetOverrides(overrides map[string]interface{}) VerifierBuilder {
-
 	// naively override values from the configuration
 	for key, val := range overrides {
 		b.config.Set(key, val)

--- a/internal/chartverifier/verifierbuilder.go
+++ b/internal/chartverifier/verifierbuilder.go
@@ -59,11 +59,14 @@ func DefaultRegistry() checks.Registry {
 type FilteredRegistry map[apiChecks.CheckName]checks.Check
 
 type verifierBuilder struct {
-	checks                      FilteredRegistry
-	config                      *viper.Viper
-	registry                    checks.Registry
-	toolVersion                 string
-	openshiftVersion            string
+	checks           FilteredRegistry
+	config           *viper.Viper
+	registry         checks.Registry
+	toolVersion      string
+	openshiftVersion string
+	//nolint:unused // TODO(komish): Need to identify if this is actually
+	// unused, or is intended to be used but its spelling is causing it
+	// to be unused coincidentally (like with a local var).
 	suppportedOpenshiftVersions string
 	webCatalogOnly              bool
 	timeout                     time.Duration

--- a/internal/chartverifier/verifierbuilder_test.go
+++ b/internal/chartverifier/verifierbuilder_test.go
@@ -19,9 +19,10 @@ package chartverifier
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/chartverifier/verifierbuilder_test.go
+++ b/internal/chartverifier/verifierbuilder_test.go
@@ -17,16 +17,16 @@
 package chartverifier
 
 import (
+	"testing"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestCertificationBuilder(t *testing.T) {
-
 	t.Run("Should fail building verifier when requiredChecks are not set", func(t *testing.T) {
 		b := NewVerifierBuilder()
 


### PR DESCRIPTION
Quite a few changes here. I had to add a couple of exceptions to the linter so that we can go through and verify functionality before we make changes.