### PR TITLE
Update dev-release tag management action

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -46,7 +46,7 @@ jobs:
 
             - name: Delete previous release and tag
               if: ${{ steps.create-tarfile.outcome == 'success' }}
-              uses: dev-drprasad/delete-tag-and-release@v0.2.0
+              uses: dev-drprasad/delete-tag-and-release@v0.2.1
               with:
                 delete_release: true # default: false
                 tag_name: ${{ env.DEV_RELEASE }} # tag name to delete


### PR DESCRIPTION
The [Dev Release](https://github.com/redhat-certification/chart-verifier/actions/runs/4736380945) workflow failed because the action we reference for managing the dev release ... well ... deleted the release of their action that we consumed (0.2.0).

For now, update it. In the future, I'd like to move away from managing dev releases in this way.