### PR TITLE
Update golangci-lint to version that supports Go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ install.gofumpt:
 	$(call go-install-tool,$(GOFUMPT),mvdan.cc/gofumpt@latest)
 
 GOLANGCI_LINT = $(shell pwd)/out/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.50.0
+GOLANGCI_LINT_VERSION ?= v1.52.2
 install.golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT):
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))\


### PR DESCRIPTION
My system was hard-crashing (OOM, full CPU saturation) when running golangci-lint 1.50.0 with Go 1.20+ so this bumps golangci-lint which seems to help