### PR TITLE
Apply gofumpt and golangci-lint to internal/chartverifier/checks package

### DIFF
--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -65,7 +65,6 @@ func (e OpenShiftSemVerErr) Error() string {
 // buildChartTestingConfiguration computes the chart testing related
 // configuration from the given check options.
 func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
-
 	// cfg will be populated with options gathered from the input
 	// check options.
 	cfg := config.Configuration{
@@ -103,7 +102,6 @@ func buildChartTestingConfiguration(opts *CheckOptions) config.Configuration {
 // functions used in this context were also ported from
 // chart-verifier.
 func ChartTesting(opts *CheckOptions) (Result, error) {
-
 	utils.LogInfo("Start chart install and test check")
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
@@ -254,7 +252,6 @@ func upgradeAndTestChart(
 	kubectl *tool.Kubectl,
 	configRelease string,
 ) chart.TestResult {
-
 	// result contains the test result; please notice that each values
 	// file in the chart's 'ci' folder will be installed and tested
 	// and the first failure makes the test fail.
@@ -338,7 +335,7 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cle
 
 	filename = path.Join(tempDir, "values.yaml")
 
-	err = ioutil.WriteFile(filename, objBytes, 0644)
+	err = ioutil.WriteFile(filename, objBytes, 0o644)
 	if err != nil {
 		return "", nil, fmt.Errorf("writing values file new contents: %w", err)
 	}
@@ -356,7 +353,6 @@ func writeObjectToTempYamlFile(obj map[string]interface{}) (filename string, cle
 // In the case the given filename is an empty string, it indicates that only the valueOverrides contents will be
 // materialized into the temporary file to be merged by `helm` when processing the chart.
 func newTempValuesFileWithOverrides(filename string, valuesOverrides map[string]interface{}) (string, func(), error) {
-
 	var obj map[string]interface{}
 
 	if filename != "" {
@@ -393,7 +389,6 @@ func installAndTestChartRelease(
 	valuesOverrides map[string]interface{},
 	configRelease string,
 ) chart.TestResult {
-
 	// valuesFiles contains all the configurations that should be
 	// executed; in other words, it performs a test matrix between
 	// values files and tests.
@@ -411,7 +406,6 @@ func installAndTestChartRelease(
 		// Use anonymous function. Otherwise deferred calls would pile up
 		// and be executed in reverse order after the loop.
 		fun := func() error {
-
 			tmpValuesFile, tmpValuesFileCleanup, err := newTempValuesFileWithOverrides(valuesFile, valuesOverrides)
 			if err != nil {
 				// it is required this operation to succeed, otherwise there are no guarantees the values informed using

--- a/internal/chartverifier/checks/charttesting_test.go
+++ b/internal/chartverifier/checks/charttesting_test.go
@@ -164,9 +164,7 @@ func TestVersionSetting(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.description, func(t *testing.T) {
-
 			err := setOCVersion(tc.opts.AnnotationHolder, tc.opts.HelmEnvSettings, tc.versioner)
 
 			if len(tc.error) > 0 {
@@ -176,9 +174,6 @@ func TestVersionSetting(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.version, tc.opts.AnnotationHolder.(*testAnnotationHolder).OpenShiftVersion)
 			}
-
 		})
-
 	}
-
 }

--- a/internal/chartverifier/checks/charttesting_test.go
+++ b/internal/chartverifier/checks/charttesting_test.go
@@ -39,7 +39,7 @@ func TestChartTesting(t *testing.T) {
 		opts        CheckOptions
 	}
 
-	chartUri, err := absPathFromSourceFileLocation("psql-service-0.1.7")
+	chartURI, err := absPathFromSourceFileLocation("psql-service-0.1.7")
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestChartTesting(t *testing.T) {
 		{
 			description: "providing a valid k8Project value should succeed",
 			opts: CheckOptions{
-				URI: chartUri,
+				URI: chartURI,
 				Values: map[string]interface{}{
 					"k8Project": "default",
 				},
@@ -72,7 +72,7 @@ func TestChartTesting(t *testing.T) {
 		{
 			description: "providing a bogus k8Project should fail",
 			opts: CheckOptions{
-				URI: chartUri,
+				URI: chartURI,
 				Values: map[string]interface{}{
 					"k8Project": "bogus",
 				},
@@ -82,10 +82,10 @@ func TestChartTesting(t *testing.T) {
 		},
 		{
 			// the chart being used in this test forces the rendered resources to have an empty namespace field, which
-			// is invalid and can't be overriden using helm's namespace option.
+			// is invalid and can't be overridden using helm's namespace option.
 			description: "empty values should fail",
 			opts: CheckOptions{
-				URI:             chartUri,
+				URI:             chartURI,
 				Values:          map[string]interface{}{},
 				ViperConfig:     viper.New(),
 				HelmEnvSettings: cli.New(),

--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -76,9 +76,7 @@ const (
 	RedHatRegistry               = "registry.redhat.io/"
 )
 
-var (
-	requiredAnnotations = [...]string{"charts.openshift.io/name"}
-)
+var requiredAnnotations = [...]string{"charts.openshift.io/name"}
 
 func notImplemented() (Result, error) {
 	return Result{Ok: false}, errors.New("not implemented")
@@ -130,7 +128,6 @@ func ContainsTest(opts *CheckOptions) (Result, error) {
 	}
 
 	return r, nil
-
 }
 
 func ContainsValues(opts *CheckOptions) (Result, error) {
@@ -190,7 +187,6 @@ func HasKubeVersion(opts *CheckOptions) (Result, error) {
 }
 
 func HasKubeVersion_V1_1(opts *CheckOptions) (Result, error) {
-
 	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
 		return NewResult(false, err.Error()), err
@@ -278,7 +274,6 @@ func CanBeInstalledWithoutClusterAdminPrivileges(opts *CheckOptions) (Result, er
 }
 
 func ImagesAreCertified(opts *CheckOptions) (Result, error) {
-
 	r := NewResult(true, "")
 
 	r = certifyImages(r, opts, "")
@@ -287,7 +282,6 @@ func ImagesAreCertified(opts *CheckOptions) (Result, error) {
 }
 
 func ImagesAreCertified_V1_1(opts *CheckOptions) (Result, error) {
-
 	r := NewResult(true, "")
 
 	r = certifyImages(r, opts, RedHatRegistry)
@@ -321,7 +315,6 @@ func RequiredAnnotationsPresent(opts *CheckOptions) (Result, error) {
 }
 
 func SignatureIsValid(opts *CheckOptions) (Result, error) {
-
 	chartPath := opts.URI
 
 	chartUrl, err := url.Parse(chartPath)
@@ -402,11 +395,9 @@ func SignatureIsValid(opts *CheckOptions) (Result, error) {
 	}
 
 	return NewResult(true, fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess)), nil
-
 }
 
 func parseImageReference(image string) pyxis.ImageReference {
-
 	imageRef := pyxis.ImageReference{}
 	imageParts := strings.Split(image, "/")
 
@@ -434,11 +425,9 @@ func parseImageReference(image string) pyxis.ImageReference {
 	}
 
 	return imageRef
-
 }
 
 func getOCPRange(kubeVersionRange string) (string, error) {
-
 	semverCompare := sprig.GenericFuncMap()["semverCompare"].(func(string, string) (bool, error))
 	minOCPVersion := ""
 	maxOCPVersion := ""
@@ -473,11 +462,9 @@ func getOCPRange(kubeVersionRange string) (string, error) {
 	}
 
 	return "", fmt.Errorf("%s : Failed to determine a minimum OCP version", KuberVersionProcessingError)
-
 }
 
 func downloadFile(fileURL *url.URL, directory string) (string, error) {
-
 	urlPath := fileURL.Path
 	segments := strings.Split(urlPath, "/")
 	fileName := segments[len(segments)-1]
@@ -514,7 +501,6 @@ func downloadFile(fileURL *url.URL, directory string) (string, error) {
 }
 
 func certifyImages(r Result, opts *CheckOptions, registry string) Result {
-
 	kubeVersion := ""
 	kubeConfig := tool.GetClientConfig(opts.HelmEnvSettings)
 	kubectl, kubeErr := tool.NewKubectl(kubeConfig)
@@ -548,7 +534,6 @@ func certifyImages(r Result, opts *CheckOptions, registry string) Result {
 			} else {
 				certified, checkImageErr := pyxis.IsImageInRegistry(imageRef)
 				if !certified {
-
 					if strings.Contains(checkImageErr.Error(), "No images found for Registry/Repository") && registry != "" {
 						if strings.HasPrefix(image, registry) {
 							r.SetSkipped(fmt.Sprintf("%s : %s", ImageCertifySkipped, image))

--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -186,6 +186,7 @@ func HasKubeVersion(opts *CheckOptions) (Result, error) {
 	return r, nil
 }
 
+//nolint:stylecheck // Note(komish) separating numeric values is a valid use case for underscores.
 func HasKubeVersion_V1_1(opts *CheckOptions) (Result, error) {
 	c, _, err := LoadChartFromURI(opts)
 	if err != nil {
@@ -281,6 +282,7 @@ func ImagesAreCertified(opts *CheckOptions) (Result, error) {
 	return r, nil
 }
 
+//nolint:stylecheck // Note(komish) separating numeric values is a valid use case for underscores.
 func ImagesAreCertified_V1_1(opts *CheckOptions) (Result, error) {
 	r := NewResult(true, "")
 
@@ -317,12 +319,12 @@ func RequiredAnnotationsPresent(opts *CheckOptions) (Result, error) {
 func SignatureIsValid(opts *CheckOptions) (Result, error) {
 	chartPath := opts.URI
 
-	chartUrl, err := url.Parse(chartPath)
+	chartURL, err := url.Parse(chartPath)
 	if err != nil {
 		return NewResult(false, fmt.Sprintf("Failed to parse chart location: %s", chartPath)), nil
 	}
 	var provFile string
-	switch chartUrl.Scheme {
+	switch chartURL.Scheme {
 	case "http", "https":
 		if strings.HasSuffix(chartPath, ".tgz") {
 			provFile = chartPath + ".prov"
@@ -331,7 +333,7 @@ func SignatureIsValid(opts *CheckOptions) (Result, error) {
 		} else {
 			return NewSkippedResult(fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess)), nil
 		}
-		provFileUrl, err := url.Parse(provFile)
+		provFileURL, err := url.Parse(provFile)
 		if err != nil {
 			return NewResult(false, fmt.Sprintf("%s : Failed to parse prov file location: %s", SignatureFailure, provFile)), nil
 		}
@@ -350,13 +352,13 @@ func SignatureIsValid(opts *CheckOptions) (Result, error) {
 			return NewResult(false, fmt.Sprintf("%s : %s : error getting cache dir:  %v", ChartSigned, SignatureFailure, err)), nil
 		}
 
-		chartPath, err = downloadFile(chartUrl, downloadDir)
+		chartPath, err = downloadFile(chartURL, downloadDir)
 		if err != nil {
-			return NewResult(false, fmt.Sprintf("%s : %s. error downloading %s:  %v", ChartSigned, SignatureIsNotPresentSuccess, chartUrl.String(), err)), nil
+			return NewResult(false, fmt.Sprintf("%s : %s. error downloading %s:  %v", ChartSigned, SignatureIsNotPresentSuccess, chartURL.String(), err)), nil
 		}
-		_, err = downloadFile(provFileUrl, downloadDir)
+		_, err = downloadFile(provFileURL, downloadDir)
 		if err != nil {
-			return NewResult(false, fmt.Sprintf("%s : %s. error downloading %s:  %v", ChartSigned, SignatureIsNotPresentSuccess, provFileUrl.String(), err)), nil
+			return NewResult(false, fmt.Sprintf("%s : %s. error downloading %s:  %v", ChartSigned, SignatureIsNotPresentSuccess, provFileURL.String(), err)), nil
 		}
 	case "file", "":
 		if strings.HasSuffix(chartPath, ".tgz") {
@@ -368,7 +370,7 @@ func SignatureIsValid(opts *CheckOptions) (Result, error) {
 			return NewSkippedResult(fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess)), nil
 		}
 	default:
-		return NewResult(false, fmt.Sprintf("%s: scheme %q not supported", SignatureFailure, chartUrl.Scheme)), nil
+		return NewResult(false, fmt.Sprintf("%s: scheme %q not supported", SignatureFailure, chartURL.Scheme)), nil
 	}
 
 	verify := action.NewVerify()
@@ -519,7 +521,6 @@ func certifyImages(r Result, opts *CheckOptions, registry string) Result {
 		r.SetResult(true, NoImagesToCertify)
 	} else {
 		for _, image := range images {
-
 			err = nil
 			imageRef := parseImageReference(image)
 

--- a/internal/chartverifier/checks/checks_test.go
+++ b/internal/chartverifier/checks/checks_test.go
@@ -250,7 +250,6 @@ func TestHasMinKubeVersion(t *testing.T) {
 			require.Equal(t, KuberVersionNotSpecified, r.Reason)
 		})
 	}
-
 }
 
 func TestNotContainCRDs(t *testing.T) {
@@ -364,19 +363,15 @@ func TestHelmLint(t *testing.T) {
 			require.Contains(t, r.Reason, HelmLintHasFailedPrefix)
 		})
 	}
-
 }
 
 func TestImageCertify(t *testing.T) {
-
 	checkImages(t, ImagesAreCertified, false)
 
 	checkImages(t, ImagesAreCertified_V1_1, true)
-
 }
 
 func checkImages(t *testing.T, fn func(*CheckOptions) (Result, error), version1_1 bool) {
-
 	type testCase struct {
 		description string
 		uri         string
@@ -439,7 +434,6 @@ func checkImages(t *testing.T, fn func(*CheckOptions) (Result, error), version1_
 }
 
 func TestImageParsing(t *testing.T) {
-
 	type testCase struct {
 		description      string
 		image            string
@@ -506,7 +500,6 @@ func TestRequiredAnnotationsPresent(t *testing.T) {
 }
 
 func TestSemVers(t *testing.T) {
-
 	// Vault: kubeVersion: '>= 1.14.0-0'
 	// IBM: kubeversion: '>=1.10.1-0'
 	// Fortanix : kubeversion: '>= 1.16.0 < 1.22.0'
@@ -547,7 +540,6 @@ func TestSemVers(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestSignatureIsValid(t *testing.T) {
@@ -561,36 +553,41 @@ func TestSignatureIsValid(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{description: "unsigned chart",
-			uri:     "chart-0.1.0-v3.no-missing-annotations.tgz",
-			keyFile: "",
-			reason:  fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
-			ok:      true, skipped: true,
+		{
+			description: "unsigned chart",
+			uri:         "chart-0.1.0-v3.no-missing-annotations.tgz",
+			keyFile:     "",
+			reason:      fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
+			ok:          true, skipped: true,
 		},
-		{description: "unsigned chart with key provided",
-			uri:     "chart-0.1.0-v3.no-missing-annotations.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
-			reason:  fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
-			ok:      true, skipped: true,
+		{
+			description: "unsigned chart with key provided",
+			uri:         "chart-0.1.0-v3.no-missing-annotations.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
+			reason:      fmt.Sprintf("%s : %s", ChartNotSigned, SignatureIsNotPresentSuccess),
+			ok:          true, skipped: true,
 		},
 
-		{description: "signed chart with valid key",
-			uri:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess),
-			ok:      true, skipped: false,
+		{
+			description: "signed chart with valid key",
+			uri:         "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.key",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureIsValidSuccess),
+			ok:          true, skipped: false,
 		},
-		{description: "signed chart with no key",
-			uri:     "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz?raw=true",
-			keyFile: "",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureNoKey),
-			ok:      true, skipped: true,
+		{
+			description: "signed chart with no key",
+			uri:         "https://github.com/redhat-certification/chart-verifier/blob/main/tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz?raw=true",
+			keyFile:     "",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureNoKey),
+			ok:          true, skipped: true,
 		},
-		{description: "signed chart with bad key",
-			uri:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
-			keyFile: "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.badkey",
-			reason:  fmt.Sprintf("%s : %s", ChartSigned, SignatureFailure),
-			ok:      false, skipped: false,
+		{
+			description: "signed chart with bad key",
+			uri:         "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz",
+			keyFile:     "../../../tests/charts/psql-service/0.1.11/psql-service-0.1.11.tgz.badkey",
+			reason:      fmt.Sprintf("%s : %s", ChartSigned, SignatureFailure),
+			ok:          false, skipped: false,
 		},
 	}
 
@@ -611,5 +608,4 @@ func TestSignatureIsValid(t *testing.T) {
 			require.Contains(t, r.Reason, tc.reason, fmt.Sprintf("%s : reason mismatch", tc.description))
 		})
 	}
-
 }

--- a/internal/chartverifier/checks/checks_test.go
+++ b/internal/chartverifier/checks/checks_test.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/pyxis"
-	"github.com/redhat-certification/chart-verifier/internal/tool"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/cli"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/pyxis"
+	"github.com/redhat-certification/chart-verifier/internal/tool"
 )
 
 func TestIsHelmV3(t *testing.T) {
@@ -441,16 +442,16 @@ func TestImageParsing(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{"Single repo Default version 1", "repo", &pyxis.ImageReference{[]string(nil), "repo", "latest", ""}},
-		{"Single repo Default version 2", "repo:", &pyxis.ImageReference{[]string(nil), "repo", "latest", ""}},
-		{"Single repo with version", "repo:1.1.8", &pyxis.ImageReference{[]string(nil), "repo", "1.1.8", ""}},
-		{"Double repo with version", "repo/product:1.1.8", &pyxis.ImageReference{[]string(nil), "repo/product", "1.1.8", ""}},
-		{"Triple repo with version", "repo/subrepo/product:1.1.8", &pyxis.ImageReference{[]string(nil), "repo/subrepo/product", "1.1.8", ""}},
-		{"Registry, single repo with version", "registry.com/product:1.1.8", &pyxis.ImageReference{[]string{"registry.com"}, "product", "1.1.8", ""}},
-		{"Registry, double repo with version", "registry.com/repo/product:1.1.8", &pyxis.ImageReference{[]string{"registry.com"}, "repo/product", "1.1.8", ""}},
-		{"Registry with port, double repo with version", "registry.com:8080/repo/product:1.1.8", &pyxis.ImageReference{[]string{"registry.com:8080"}, "repo/product", "1.1.8", ""}},
-		{"Single repo Sha256", "repo@sha256:12345", &pyxis.ImageReference{[]string(nil), "repo", "", "sha256:12345"}},
-		{"Single repo Sha128", "repo@sha128:12345", &pyxis.ImageReference{[]string(nil), "repo", "", "sha128:12345"}},
+		{"Single repo Default version 1", "repo", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo", Tag: "latest", Sha: ""}},
+		{"Single repo Default version 2", "repo:", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo", Tag: "latest", Sha: ""}},
+		{"Single repo with version", "repo:1.1.8", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo", Tag: "1.1.8", Sha: ""}},
+		{"Double repo with version", "repo/product:1.1.8", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo/product", Tag: "1.1.8", Sha: ""}},
+		{"Triple repo with version", "repo/subrepo/product:1.1.8", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo/subrepo/product", Tag: "1.1.8", Sha: ""}},
+		{"Registry, single repo with version", "registry.com/product:1.1.8", &pyxis.ImageReference{Registries: []string{"registry.com"}, Repository: "product", Tag: "1.1.8", Sha: ""}},
+		{"Registry, double repo with version", "registry.com/repo/product:1.1.8", &pyxis.ImageReference{Registries: []string{"registry.com"}, Repository: "repo/product", Tag: "1.1.8", Sha: ""}},
+		{"Registry with port, double repo with version", "registry.com:8080/repo/product:1.1.8", &pyxis.ImageReference{Registries: []string{"registry.com:8080"}, Repository: "repo/product", Tag: "1.1.8", Sha: ""}},
+		{"Single repo Sha256", "repo@sha256:12345", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo", Tag: "", Sha: "sha256:12345"}},
+		{"Single repo Sha128", "repo@sha128:12345", &pyxis.ImageReference{Registries: []string(nil), Repository: "repo", Tag: "", Sha: "sha128:12345"}},
 	}
 
 	for _, testCase := range testCases {
@@ -511,6 +512,8 @@ func TestSemVers(t *testing.T) {
 		OCPRange    string
 	}
 
+	// nolint:unused // TODO(komish): Identify historical purpose of this type
+	// before considering for removal.
 	type TestError struct {
 		expectedOCPRange string
 		gotOCORange      string

--- a/internal/chartverifier/checks/helm.go
+++ b/internal/chartverifier/checks/helm.go
@@ -194,7 +194,7 @@ func IsChartNotFound(err error) bool {
 	return ok
 }
 
-func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersionString string) ([]string, error) {
+func getImageReferences(chartURI string, vals map[string]interface{}, kubeVersionString string) ([]string, error) {
 	capabilities := chartutil.DefaultCapabilities
 
 	if kubeVersionString == "" {
@@ -217,7 +217,7 @@ func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersio
 	mem.SetNamespace("TestNamespace")
 	actionConfig.Releases = storage.Init(mem)
 
-	txt, err := actions.RenderManifests("test-release", chartUri, vals, actionConfig)
+	txt, err := actions.RenderManifests("test-release", chartURI, vals, actionConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/chartverifier/checks/helm.go
+++ b/internal/chartverifier/checks/helm.go
@@ -195,7 +195,6 @@ func IsChartNotFound(err error) bool {
 }
 
 func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersionString string) ([]string, error) {
-
 	capabilities := chartutil.DefaultCapabilities
 
 	if kubeVersionString == "" {
@@ -224,11 +223,9 @@ func getImageReferences(chartUri string, vals map[string]interface{}, kubeVersio
 	}
 
 	return getImagesFromContent(txt)
-
 }
 
 func getImagesFromContent(content string) ([]string, error) {
-
 	imagesMap := make(map[string]bool)
 
 	type ImageRef struct {
@@ -259,7 +256,6 @@ func getImagesFromContent(content string) ([]string, error) {
 	}
 
 	return images, err
-
 }
 
 func getNextLine(reader *bufio.Reader) (string, error) {
@@ -284,5 +280,4 @@ func getCacheDir(opts *CheckOptions) string {
 		}
 	}
 	return path.Join(cacheDir, "chart-verifier")
-
 }

--- a/internal/chartverifier/checks/helm_test.go
+++ b/internal/chartverifier/checks/helm_test.go
@@ -147,7 +147,6 @@ func TestLoadChartFromURI(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-
 	type testCase struct {
 		description string
 		uri         string
@@ -155,10 +154,12 @@ func TestTemplate(t *testing.T) {
 	}
 
 	TestCases := []testCase{
-		{description: "chart-0.1.0-v3.valid.tgz images ", uri: "chart-0.1.0-v3.valid.tgz", images: []string{"registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest",
+		{description: "chart-0.1.0-v3.valid.tgz images ", uri: "chart-0.1.0-v3.valid.tgz", images: []string{
+			"registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest",
 			"snyk/kubernetes-operator", "rhscl/mongodb-36-rhel7:1-65",
 			"icr.io/cpopen/ibmcloud-object-storage-driver@sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f",
-			"icr.io/cpopen/ibmcloud-object-storage-plugin@sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}},
+			"icr.io/cpopen/ibmcloud-object-storage-plugin@sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e",
+		}},
 		{description: "chart-0.1.0-v3.with-crd.tgz", uri: "chart-0.1.0-v3.with-crd.tgz", images: []string{"nginx:1.16.0", "busybox"}},
 		{description: "chart-0.1.0-v3.with-csi.tgz", uri: "chart-0.1.0-v3.with-csi.tgz", images: []string{"nginx:1.16.0"}},
 	}
@@ -176,7 +177,6 @@ func TestTemplate(t *testing.T) {
 }
 
 func TestLongLineTemplate(t *testing.T) {
-
 	content, err := ioutil.ReadFile("templates/test-template.yaml")
 	require.NoError(t, err)
 
@@ -187,5 +187,4 @@ func TestLongLineTemplate(t *testing.T) {
 
 	require.Contains(t, images, "1.1.1/cv-test/image1:tag-123")
 	require.Contains(t, images, "1.1.2/cv-test/image2:tag-223")
-
 }

--- a/internal/chartverifier/checks/registry.go
+++ b/internal/chartverifier/checks/registry.go
@@ -19,9 +19,10 @@ package checks
 import (
 	"time"
 
-	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"github.com/spf13/viper"
 	helmcli "helm.sh/helm/v3/pkg/cli"
+
+	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 )
 
 type Result struct {
@@ -83,12 +84,12 @@ type AnnotationHolder interface {
 	SetSupportedOpenShiftVersions(versions string)
 }
 
-type CheckId struct {
+type CheckID struct {
 	Name    apiChecks.CheckName
 	Version string
 }
 type Check struct {
-	CheckId CheckId
+	CheckID CheckID
 	Type    apiChecks.CheckType
 	Func    CheckFunc
 }
@@ -117,12 +118,12 @@ type CheckOptions struct {
 type CheckFunc func(options *CheckOptions) (Result, error)
 
 type Registry interface {
-	Get(id CheckId) (Check, bool)
+	Get(id CheckID) (Check, bool)
 	Add(name apiChecks.CheckName, version string, checkFunc CheckFunc) Registry
 	AllChecks() DefaultRegistry
 }
 
-type DefaultRegistry map[CheckId]Check
+type DefaultRegistry map[CheckID]Check
 
 func (r *DefaultRegistry) AllChecks() DefaultRegistry {
 	return *r
@@ -132,13 +133,13 @@ func NewRegistry() Registry {
 	return &DefaultRegistry{}
 }
 
-func (r *DefaultRegistry) Get(id CheckId) (Check, bool) {
+func (r *DefaultRegistry) Get(id CheckID) (Check, bool) {
 	v, ok := (*r)[id]
 	return v, ok
 }
 
 func (r *DefaultRegistry) Add(name apiChecks.CheckName, version string, checkFunc CheckFunc) Registry {
-	check := Check{CheckId: CheckId{Name: name, Version: version}, Func: checkFunc}
-	(*r)[check.CheckId] = check
+	check := Check{CheckID: CheckID{Name: name, Version: version}, Func: checkFunc}
+	(*r)[check.CheckID] = check
 	return r
 }

--- a/internal/chartverifier/checks/registry.go
+++ b/internal/chartverifier/checks/registry.go
@@ -138,7 +138,6 @@ func (r *DefaultRegistry) Get(id CheckId) (Check, bool) {
 }
 
 func (r *DefaultRegistry) Add(name apiChecks.CheckName, version string, checkFunc CheckFunc) Registry {
-
 	check := Check{CheckId: CheckId{Name: name, Version: version}, Func: checkFunc}
 	(*r)[check.CheckId] = check
 	return r

--- a/internal/chartverifier/profiles/profile.go
+++ b/internal/chartverifier/profiles/profile.go
@@ -2,14 +2,15 @@ package profiles
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
 	"github.com/redhat-certification/chart-verifier/internal/profileconfig"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
-	"regexp"
-	"strings"
 )
 
 type Annotation string
@@ -143,7 +144,7 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 	for _, check := range profile.Checks {
 		splitter := regexp.MustCompile(`/`)
 		splitCheck := splitter.Split(check.Name, -1)
-		checkIndex := checks.CheckId{Name: apiChecks.CheckName(splitCheck[1]), Version: splitCheck[0]}
+		checkIndex := checks.CheckID{Name: apiChecks.CheckName(splitCheck[1]), Version: splitCheck[0]}
 		if newCheck, ok := registry[checkIndex]; ok {
 			newCheck.Type = check.Type
 			filteredChecks[checkIndex.Name] = newCheck

--- a/internal/chartverifier/profiles/profile_test.go
+++ b/internal/chartverifier/profiles/profile_test.go
@@ -134,12 +134,12 @@ func TestProfileFilter(t *testing.T) {
 	defaultRegistry.Add("BadContainsTestName", "v1.o", checks.ContainsTest)
 
 	expectedChecks := FilteredRegistry{}
-	expectedChecks[apiChecks.HasReadme] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.HasReadme, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.HasReadme}
-	expectedChecks[apiChecks.IsHelmV3] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.IsHelmV3, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.IsHelmV3}
-	expectedChecks[apiChecks.ContainsTest] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.ContainsTest, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsTest}
-	expectedChecks[apiChecks.ContainsValues] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.ContainsValues, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsValues}
-	expectedChecks[apiChecks.HasKubeVersion] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.HasKubeVersion, Version: checkVersion11}, Type: apiChecks.MandatoryCheckType, Func: checks.HasKubeVersion_V1_1}
-	expectedChecks[apiChecks.ImagesAreCertified] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.ImagesAreCertified, Version: checkVersion11}, Type: apiChecks.MandatoryCheckType, Func: checks.ImagesAreCertified_V1_1}
+	expectedChecks[apiChecks.HasReadme] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.HasReadme, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.HasReadme}
+	expectedChecks[apiChecks.IsHelmV3] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.IsHelmV3, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.IsHelmV3}
+	expectedChecks[apiChecks.ContainsTest] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.ContainsTest, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsTest}
+	expectedChecks[apiChecks.ContainsValues] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.ContainsValues, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsValues}
+	expectedChecks[apiChecks.HasKubeVersion] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.HasKubeVersion, Version: checkVersion11}, Type: apiChecks.MandatoryCheckType, Func: checks.HasKubeVersion_V1_1}
+	expectedChecks[apiChecks.ImagesAreCertified] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.ImagesAreCertified, Version: checkVersion11}, Type: apiChecks.MandatoryCheckType, Func: checks.ImagesAreCertified_V1_1}
 
 	config := make(map[string]interface{})
 	t.Run("Checks filtered using profile subset", func(t *testing.T) {
@@ -156,12 +156,12 @@ func TestProfileFilter(t *testing.T) {
 	defaultRegistry.Add(apiChecks.ChartTesting, checkVersion10, checks.ChartTesting)
 	defaultRegistry.Add(apiChecks.RequiredAnnotationsPresent, checkVersion10, checks.RequiredAnnotationsPresent)
 
-	expectedChecks[apiChecks.ContainsValuesSchema] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.ContainsValuesSchema, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsValuesSchema}
-	expectedChecks[apiChecks.NotContainsCRDs] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.NotContainsCRDs, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.NotContainCRDs}
-	expectedChecks[apiChecks.HelmLint] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.HelmLint, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.HelmLint}
-	expectedChecks[apiChecks.NotContainCsiObjects] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.NotContainCsiObjects, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.NotContainCSIObjects}
-	expectedChecks[apiChecks.ChartTesting] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.ChartTesting, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ChartTesting}
-	expectedChecks[apiChecks.RequiredAnnotationsPresent] = checks.Check{CheckId: checks.CheckId{Name: apiChecks.RequiredAnnotationsPresent, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.RequiredAnnotationsPresent}
+	expectedChecks[apiChecks.ContainsValuesSchema] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.ContainsValuesSchema, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ContainsValuesSchema}
+	expectedChecks[apiChecks.NotContainsCRDs] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.NotContainsCRDs, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.NotContainCRDs}
+	expectedChecks[apiChecks.HelmLint] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.HelmLint, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.HelmLint}
+	expectedChecks[apiChecks.NotContainCsiObjects] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.NotContainCsiObjects, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.NotContainCSIObjects}
+	expectedChecks[apiChecks.ChartTesting] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.ChartTesting, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.ChartTesting}
+	expectedChecks[apiChecks.RequiredAnnotationsPresent] = checks.Check{CheckID: checks.CheckID{Name: apiChecks.RequiredAnnotationsPresent, Version: checkVersion10}, Type: apiChecks.MandatoryCheckType, Func: checks.RequiredAnnotationsPresent}
 
 	t.Run("Checks filtered using profile - full set", func(t *testing.T) {
 		filteredChecks := New(config).FilterChecks(defaultRegistry.AllChecks())
@@ -178,8 +178,8 @@ func CompareCheckMaps(t *testing.T, expectedChecks, filteredChecks FilteredRegis
 		if !ok {
 			assert.True(t, ok, "Entry not found in expected: %s", k)
 		} else {
-			assert.Equal(t, v.CheckId.Name, expectedChecks[k].CheckId.Name, fmt.Sprintf("%s: Map names do not match! got:%s, expect:%s ", k, v.CheckId.Name, expectedChecks[k].CheckId.Name))
-			assert.Equal(t, v.CheckId.Version, expectedChecks[k].CheckId.Version, fmt.Sprintf("%s: Map versions do not match! got:%s, expect:%s", k, v.CheckId.Version, expectedChecks[k].CheckId.Version))
+			assert.Equal(t, v.CheckID.Name, expectedChecks[k].CheckID.Name, fmt.Sprintf("%s: Map names do not match! got:%s, expect:%s ", k, v.CheckID.Name, expectedChecks[k].CheckID.Name))
+			assert.Equal(t, v.CheckID.Version, expectedChecks[k].CheckID.Version, fmt.Sprintf("%s: Map versions do not match! got:%s, expect:%s", k, v.CheckID.Version, expectedChecks[k].CheckID.Version))
 			assert.Equal(t, v.Type, expectedChecks[k].Type, fmt.Sprintf("%s: Map types do not match! got:%s, expect:%s", k, v.Type, expectedChecks[k].Type))
 			runFunc := filepath.Base(runtime.FuncForPC(reflect.ValueOf(v.Func).Pointer()).Name())
 			expectFunc := filepath.Base(runtime.FuncForPC(reflect.ValueOf(expectedChecks[k].Func).Pointer()).Name())

--- a/internal/chartverifier/report.go
+++ b/internal/chartverifier/report.go
@@ -18,6 +18,7 @@ package chartverifier
 
 import (
 	"fmt"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
 	apiReport "github.com/redhat-certification/chart-verifier/pkg/chartverifier/report"
@@ -46,7 +47,7 @@ func newReport() InternalReport {
 func (ir *InternalReport) AddCheck(check checks.Check) *InternalCheckReport {
 	newCheck := InternalCheckReport{}
 	newCheck.APICheckReport = apiReport.CheckReport{}
-	newCheck.APICheckReport.Check = apiChecks.CheckName(fmt.Sprintf("%s/%s", check.CheckId.Version, check.CheckId.Name))
+	newCheck.APICheckReport.Check = apiChecks.CheckName(fmt.Sprintf("%s/%s", check.CheckID.Version, check.CheckID.Name))
 	newCheck.APICheckReport.Type = apiChecks.CheckType(check.Type)
 	newCheck.APICheckReport.Outcome = apiReport.UnknownOutcomeType
 	ir.APIReport.Results = append(ir.APIReport.Results, &newCheck.APICheckReport)

--- a/internal/chartverifier/reportBuilder.go
+++ b/internal/chartverifier/reportBuilder.go
@@ -114,9 +114,9 @@ func (r *reportBuilder) SetPublicKeyDigest(digest string) ReportBuilder {
 func (r *reportBuilder) AddCheck(check checks.Check, result checks.Result) ReportBuilder {
 	checkReport := r.Report.AddCheck(check)
 	checkReport.SetResult(result.Ok, result.Skipped, result.Reason)
-	utils.LogInfo(fmt.Sprintf("Check: %s:%s result : %t", check.CheckId.Name, check.CheckId.Version, result.Ok))
+	utils.LogInfo(fmt.Sprintf("Check: %s:%s result : %t", check.CheckID.Name, check.CheckID.Version, result.Ok))
 	if !result.Ok {
-		utils.LogInfo(fmt.Sprintf("Check: %s:%s reason : %s", check.CheckId.Name, check.CheckId.Version, result.Reason))
+		utils.LogInfo(fmt.Sprintf("Check: %s:%s reason : %s", check.CheckID.Name, check.CheckID.Version, result.Reason))
 	}
 	return r
 }

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -108,7 +108,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 	for _, check := range c.requiredChecks {
 
 		if check.Func == nil {
-			return nil, CheckNotFoundErr(check.CheckId.Name)
+			return nil, CheckNotFoundErr(check.CheckID.Name)
 		}
 		holder := AnnotationHolder{Holder: result,
 			CertifiedOpenShiftVersionFlag: c.openshiftVersion}
@@ -117,7 +117,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 			HelmEnvSettings:    c.settings,
 			URI:                uri,
 			Values:             c.values,
-			ViperConfig:        c.subConfig(string(check.CheckId.Name)),
+			ViperConfig:        c.subConfig(string(check.CheckID.Name)),
 			AnnotationHolder:   &holder,
 			Timeout:            c.timeout,
 			HelmInstallTimeout: c.helmInstallTimeout,
@@ -129,7 +129,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 		}
 		_ = result.AddCheck(check, r)
 
-		if check.CheckId.Name == apiChecks.SignatureIsValid {
+		if check.CheckID.Name == apiChecks.SignatureIsValid {
 			if len(c.publicKeys) == 1 && strings.Contains(r.Reason, checks.ChartSigned) {
 				publicKeyDigest, digestErr := tool.GetPublicKeyDigest(c.publicKeys[0])
 				if digestErr != nil {

--- a/internal/chartverifier/verifier_test.go
+++ b/internal/chartverifier/verifier_test.go
@@ -19,8 +19,9 @@ package chartverifier
 import (
 	"context"
 	"errors"
-	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"testing"
+
+	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -49,7 +50,7 @@ func TestVerifier_Verify(t *testing.T) {
 
 	require.NoError(t, testutil.ServeCharts(ctx, addr, "./checks/"))
 
-	dummyCheck := checks.Check{CheckId: checks.CheckId{Name: "dummy-check"}}
+	dummyCheck := checks.Check{CheckID: checks.CheckID{Name: "dummy-check"}}
 
 	erroredCheck := func(_ *checks.CheckOptions) (checks.Result, error) {
 		return checks.Result{}, errors.New("artificial error")
@@ -85,7 +86,7 @@ func TestVerifier_Verify(t *testing.T) {
 			settings:       cli.New(),
 			config:         viper.New(),
 			profile:        profiles.Get(),
-			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", erroredCheck),
+			registry:       checks.NewRegistry().Add(dummyCheck.CheckID.Name, "v1.0", erroredCheck),
 			requiredChecks: []checks.Check{dummyCheck},
 		}
 
@@ -100,7 +101,7 @@ func TestVerifier_Verify(t *testing.T) {
 			settings:         cli.New(),
 			config:           viper.New(),
 			profile:          profiles.Get(),
-			registry:         checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", negativeCheck),
+			registry:         checks.NewRegistry().Add(dummyCheck.CheckID.Name, "v1.0", negativeCheck),
 			requiredChecks:   []checks.Check{dummyCheck},
 			openshiftVersion: "4.9",
 		}
@@ -117,7 +118,7 @@ func TestVerifier_Verify(t *testing.T) {
 			settings:       cli.New(),
 			config:         viper.New(),
 			profile:        profiles.Get(),
-			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
+			registry:       checks.NewRegistry().Add(dummyCheck.CheckID.Name, "v1.0", positiveCheck),
 			requiredChecks: []checks.Check{dummyCheck},
 			webCatalogOnly: true,
 		}
@@ -134,7 +135,7 @@ func TestVerifier_Verify(t *testing.T) {
 			settings:       cli.New(),
 			config:         viper.New(),
 			profile:        profiles.Get(),
-			registry:       checks.NewRegistry().Add(dummyCheck.CheckId.Name, "v1.0", positiveCheck),
+			registry:       checks.NewRegistry().Add(dummyCheck.CheckID.Name, "v1.0", positiveCheck),
 			requiredChecks: []checks.Check{dummyCheck},
 			webCatalogOnly: true,
 		}

--- a/internal/chartverifier/verifierbuilder_test.go
+++ b/internal/chartverifier/verifierbuilder_test.go
@@ -17,10 +17,11 @@
 package chartverifier
 
 import (
+	"testing"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/profiles"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,8 +40,8 @@ func TestCertificationBuilder(t *testing.T) {
 		b := NewVerifierBuilder()
 
 		checkMap := make(FilteredRegistry)
-		checkMap["a"] = checks.Check{CheckId: checks.CheckId{Name: "a"}}
-		checkMap["b"] = checks.Check{CheckId: checks.CheckId{Name: "b"}}
+		checkMap["a"] = checks.Check{CheckID: checks.CheckID{Name: "a"}}
+		checkMap["b"] = checks.Check{CheckID: checks.CheckID{Name: "b"}}
 
 		c, err := b.
 			SetChecks(checkMap).


### PR DESCRIPTION
The checks package is rather large so lots of changes here, but mostly negligible.