### PR TITLE
Apply gofumpt and golangci-lint to internal/chartverifier/*

### DIFF
--- a/internal/chartverifier/profiles/profile.go
+++ b/internal/chartverifier/profiles/profile.go
@@ -5,12 +5,13 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/mod/semver"
+	"gopkg.in/yaml.v3"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
 	"github.com/redhat-certification/chart-verifier/internal/profileconfig"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
-	"golang.org/x/mod/semver"
-	"gopkg.in/yaml.v3"
 )
 
 type (
@@ -74,9 +75,7 @@ func Get() *Profile {
 func New(values map[string]interface{}) *Profile {
 	profileVendorType := VendorTypeDefault
 	var profileVersion string
-
 	if values != nil {
-
 		if vendorType, ok := values[VendorTypeConfigName]; ok {
 			profileVendorType = VendorType(strings.ToLower(fmt.Sprintf("%v", vendorType)))
 		}

--- a/internal/chartverifier/profiles/profile.go
+++ b/internal/chartverifier/profiles/profile.go
@@ -13,9 +13,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Annotation string
-type VendorType string
-type VendorVersion string
+type (
+	Annotation    string
+	VendorType    string
+	VendorVersion string
+)
 
 const (
 	DigestAnnotation                 Annotation = "Digest"
@@ -70,7 +72,6 @@ func Get() *Profile {
 }
 
 func New(values map[string]interface{}) *Profile {
-
 	profileVendorType := VendorTypeDefault
 	var profileVersion string
 
@@ -114,7 +115,6 @@ func New(values map[string]interface{}) *Profile {
 
 // Get all profiles in the profiles directory, and any subdirectories, and add each to the profile map
 func getProfiles() {
-
 	profileFiles, err := profileconfig.GetProfiles()
 	if err != nil {
 		return
@@ -138,7 +138,6 @@ func getProfiles() {
 }
 
 func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRegistry {
-
 	filteredChecks := make(map[apiChecks.CheckName]checks.Check)
 
 	for _, check := range profile.Checks {
@@ -152,11 +151,9 @@ func (profile *Profile) FilterChecks(registry checks.DefaultRegistry) FilteredRe
 	}
 
 	return filteredChecks
-
 }
 
 func readProfile(profileBytes []byte) (*Profile, error) {
-
 	profile := &Profile{}
 	err := yaml.Unmarshal(profileBytes, profile)
 	if err != nil {
@@ -164,5 +161,4 @@ func readProfile(profileBytes []byte) (*Profile, error) {
 	}
 
 	return profile, nil
-
 }

--- a/internal/chartverifier/profiles/profile_test.go
+++ b/internal/chartverifier/profiles/profile_test.go
@@ -29,7 +29,6 @@ const (
 )
 
 func TestProfile(t *testing.T) {
-
 	testProfile := getDefaultProfile("test")
 	testProfile.Name = "profile-partner-1.2"
 	config := make(map[string]interface{})
@@ -68,11 +67,9 @@ func TestProfile(t *testing.T) {
 			assert.True(t, cmp.Equal(diskProfile, testProfile), "profiles do not match")
 		}
 	})
-
 }
 
 func TestGetProfiles(t *testing.T) {
-
 	getAndCheckProfile(t, PartnerVendorType, PartnerVendorType, configVersion11, configVersion11)
 	getAndCheckProfile(t, RedhatVendorType, RedhatVendorType, configVersion11, configVersion11)
 	getAndCheckProfile(t, CommunityVendorType, CommunityVendorType, configVersion11, configVersion11)
@@ -88,7 +85,6 @@ func TestGetProfiles(t *testing.T) {
 }
 
 func getAndCheckProfile(t *testing.T, configVendorType, expectVendorType VendorType, configVersion, expectVersion string) {
-
 	config := make(map[string]interface{})
 
 	if len(configVendorType) > 0 {
@@ -105,11 +101,10 @@ func getAndCheckProfile(t *testing.T, configVendorType, expectVendorType VendorT
 		profile = Get()
 		assert.Equal(t, expectVendorType, profile.Vendor, "VendorType did not match")
 		assert.Equal(t, expectVersion, profile.Version, "Version did not match")
-
 	})
 }
-func TestProfileFilter(t *testing.T) {
 
+func TestProfileFilter(t *testing.T) {
 	defaultRegistry := checks.NewRegistry()
 
 	defaultRegistry.Add(apiChecks.HasReadme, checkVersion10, checks.HasReadme)
@@ -167,11 +162,9 @@ func TestProfileFilter(t *testing.T) {
 		filteredChecks := New(config).FilterChecks(defaultRegistry.AllChecks())
 		CompareCheckMaps(t, expectedChecks, filteredChecks)
 	})
-
 }
 
 func CompareCheckMaps(t *testing.T, expectedChecks, filteredChecks FilteredRegistry) {
-
 	assert.Equal(t, len(expectedChecks), len(filteredChecks), fmt.Sprintf("Expected map length : %d does not match returned mao length : %d", len(expectedChecks), len(filteredChecks)))
 	for k, v := range filteredChecks {
 		_, ok := expectedChecks[k]

--- a/internal/chartverifier/profiles/profile_test.go
+++ b/internal/chartverifier/profiles/profile_test.go
@@ -9,14 +9,17 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/checks"
 	apiChecks "github.com/redhat-certification/chart-verifier/pkg/chartverifier/checks"
-	"github.com/stretchr/testify/assert"
 )
 
 const (
-	NoVersion           string     = ""
-	configVersion00     string     = "v0.0"
+	NoVersion       string = ""
+	configVersion00 string = "v0.0"
+	//nolint:deadcode // TODO(komish) identify where this was intended to be used, or remove.
+	// This should be unused but its triggering as deadcode which is replaced by the unused linter.
 	configVersion10     string     = "v1.0"
 	configVersion11     string     = "v1.1"
 	configVersion12     string     = "v1.2"

--- a/internal/chartverifier/pyxis/pyxis.go
+++ b/internal/chartverifier/pyxis/pyxis.go
@@ -17,7 +17,6 @@ package pyxis
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -26,7 +25,7 @@ import (
 	"github.com/redhat-certification/chart-verifier/internal/chartverifier/utils"
 )
 
-var pyxisBaseUrl = "https://catalog.redhat.com/api/containers/v1/repositories"
+var pyxisBaseURL = "https://catalog.redhat.com/api/containers/v1/repositories"
 
 type RepositoriesBody struct {
 	PyxisRepositories []PyxisRepository `json:"data"`
@@ -36,7 +35,7 @@ type RepositoriesBody struct {
 }
 
 type PyxisRepository struct {
-	Id          string `json:"_id"`
+	ID          string `json:"_id"`
 	Repository  string `json:"repository"`
 	VendorLabel string `json:"vendor_label"`
 	Registry    string `json:"registry"`
@@ -50,8 +49,8 @@ type RegistriesBody struct {
 }
 
 type PyxisRegistry struct {
-	Id           string               `json:"_id"`
-	ImageId      string               `json:"image_id"`
+	ID           string               `json:"_id"`
+	ImageID      string               `json:"image_id"`
 	Repositories []RegistryRepository `json:"repositories"`
 }
 
@@ -83,9 +82,8 @@ func GetImageRegistries(repository string) ([]string, error) {
 	allDataRead := false
 
 	for !allDataRead {
-
-		utils.LogInfo(fmt.Sprintf("Look for repository %s at %s, page %d", repository, pyxisBaseUrl, nextPage))
-		req, _ := http.NewRequest("GET", pyxisBaseUrl, nil)
+		utils.LogInfo(fmt.Sprintf("Look for repository %s at %s, page %d", repository, pyxisBaseURL, nextPage))
+		req, _ := http.NewRequest("GET", pyxisBaseURL, nil)
 		queryString := req.URL.Query()
 		queryString.Add("filter", fmt.Sprintf("repository==%s", repository))
 		queryString.Add("page_size", "100")
@@ -95,13 +93,15 @@ func GetImageRegistries(repository string) ([]string, error) {
 		client := &http.Client{}
 		resp, reqErr := client.Do(req)
 		if reqErr != nil {
-			err = errors.New(fmt.Sprintf("Error getting repository %s : %v\n", repository, err))
+			err = fmt.Errorf("error getting repository %s : %v", repository, err)
 		} else {
 			if resp.StatusCode == 200 {
 				// #nosec G307
 				defer resp.Body.Close()
 				body, _ := ioutil.ReadAll(resp.Body)
 				var repositoriesBody RepositoriesBody
+				//nolint:errcheck // TODO(komish): this should be checked, but we really need
+				// to look at refactoring this block in its entirety. Delay fixing this until then.
 				json.Unmarshal(body, &repositoriesBody)
 
 				if total == 0 {
@@ -120,10 +120,10 @@ func GetImageRegistries(repository string) ([]string, error) {
 						utils.LogInfo(fmt.Sprintf("Found repository in registry: %s", repo.Registry))
 					}
 				} else {
-					err = errors.New(fmt.Sprintf("Respository not found: %s", repository))
+					err = fmt.Errorf("repository not found: %s", repository)
 				}
 			} else {
-				err = errors.New(fmt.Sprintf("Bad response code from Pyxis: %d : %s", resp.StatusCode, req.URL))
+				err = fmt.Errorf("bad response code from Pyxis: %d : %s", resp.StatusCode, req.URL)
 			}
 		}
 	}
@@ -142,18 +142,16 @@ func IsImageInRegistry(imageRef ImageReference) (bool, error) {
 
 Loops:
 	for _, registry := range imageRef.Registries {
-
 		read := 0
 		total := 0
 		nextPage := 0
 		allDataRead := false
 
-		requestUrl := fmt.Sprintf("%s/registry/%s/repository/%s/images", pyxisBaseUrl, registry, imageRef.Repository)
-		utils.LogInfo(fmt.Sprintf("Search url: %s, tag: %s, sha: %s ", requestUrl, imageRef.Tag, imageRef.Sha))
+		requestURL := fmt.Sprintf("%s/registry/%s/repository/%s/images", pyxisBaseURL, registry, imageRef.Repository)
+		utils.LogInfo(fmt.Sprintf("Search url: %s, tag: %s, sha: %s ", requestURL, imageRef.Tag, imageRef.Sha))
 
 		for !allDataRead && err == nil && !found {
-
-			req, _ := http.NewRequest("GET", requestUrl, nil)
+			req, _ := http.NewRequest("GET", requestURL, nil)
 			queryString := req.URL.Query()
 			queryString.Add("filter", fmt.Sprintf("repositories=em=(repository==%s;registry==%s)", imageRef.Repository, registry))
 			queryString.Add("page_size", "100")
@@ -167,8 +165,13 @@ Loops:
 				if resp.StatusCode == 200 {
 					// #nosec G307
 					defer resp.Body.Close()
+					// TODO(komish): this should be checked, but we really need
+					// to look at refactoring this block in its entirety. Delay fixing this until then
+					//
+					//nolint:errcheck
 					body, _ := ioutil.ReadAll(resp.Body)
 					var registriesBody RegistriesBody
+					//nolint:errcheck
 					json.Unmarshal(body, &registriesBody)
 
 					if total == 0 {
@@ -186,13 +189,13 @@ Loops:
 						found = false
 						for _, reg := range registriesBody.PyxisRegistries {
 							if len(imageRef.Sha) > 0 {
-								if imageRef.Sha == reg.ImageId {
+								if imageRef.Sha == reg.ImageID {
 									utils.LogInfo(fmt.Sprintf("sha found: %s", imageRef.Sha))
 									found = true
 									err = nil
 									continue Loops
 								} else {
-									shas = append(shas, reg.ImageId)
+									shas = append(shas, reg.ImageID)
 								}
 							} else {
 								for _, repo := range reg.Repositories {
@@ -214,10 +217,16 @@ Loops:
 							}
 						}
 					} else {
-						err = errors.New(fmt.Sprintf("No images found for Registry/Repository: %s/%s", registry, imageRef.Repository))
+						// Note(komish): For now, leaving this capitalized "No" because this value is checked in the
+						// checks library to decide whether or not a check is considered acceptably passed, specifically
+						// when working with certified images or internal registries. Better to deal with this
+						// by itself at a future date than introduce a potentially subtle bug.
+						//
+						//nolint:stylecheck
+						err = fmt.Errorf("No images found for Registry/Repository: %s/%s", registry, imageRef.Repository)
 					}
 				} else {
-					err = errors.New(fmt.Sprintf("Bad response code %d from pyxis request : %s", resp.StatusCode, requestUrl))
+					err = fmt.Errorf("bad response code %d from pyxis request : %s", resp.StatusCode, requestURL)
 				}
 			} else {
 				err = reqErr
@@ -227,9 +236,9 @@ Loops:
 	if !found {
 		if err == nil {
 			if len(imageRef.Sha) > 0 {
-				err = errors.New(fmt.Sprintf("Digest %s not found. Found : %s", imageRef.Sha, strings.Join(shas, ", ")))
+				err = fmt.Errorf("digest %s not found. Found : %s", imageRef.Sha, strings.Join(shas, ", "))
 			} else {
-				err = errors.New(fmt.Sprintf("Tag %s not found. Found : %s", imageRef.Tag, strings.Join(tags, ", ")))
+				err = fmt.Errorf("tag %s not found. Found : %s", imageRef.Tag, strings.Join(tags, ", "))
 			}
 		}
 	}

--- a/internal/chartverifier/pyxis/pyxis.go
+++ b/internal/chartverifier/pyxis/pyxis.go
@@ -134,7 +134,6 @@ func GetImageRegistries(repository string) ([]string, error) {
 }
 
 func IsImageInRegistry(imageRef ImageReference) (bool, error) {
-
 	var err error
 	found := false
 

--- a/internal/chartverifier/pyxis/pyxis_test.go
+++ b/internal/chartverifier/pyxis/pyxis_test.go
@@ -31,12 +31,12 @@ func Test_getImageRegistries(t *testing.T) {
 	}
 
 	PassTestCases := []testCase{
-		{description: "Test rhscl respository", repository: "rhscl/postgresql-10-rhel7", registry: "registry.access.redhat.com", message: ""},
-		{description: "Test rhel6.7 respository", repository: "rhel6.7", registry: "registry.access.redhat.com", message: ""},
-		{description: "Test rhel8/nginx-116 respository", repository: "rhel8/nginx-116", registry: "registry.access.redhat.com", message: ""},
-		{description: "Test ibm/nginx respository", repository: "ibm/nginx", registry: "non_registry", message: ""},
-		{description: "Test turbonomic/zookeeper respository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""},
+		{description: "Test rhscl repository", repository: "rhscl/postgresql-10-rhel7", registry: "registry.access.redhat.com", message: ""},
+		{description: "Test rhel6.7 repository", repository: "rhel6.7", registry: "registry.access.redhat.com", message: ""},
+		{description: "Test rhel8/nginx-116 repository", repository: "rhel8/nginx-116", registry: "registry.access.redhat.com", message: ""},
+		{description: "Test ibm/nginx repository", repository: "ibm/nginx", registry: "non_registry", message: ""},
+		{description: "Test turbonomic/zookeeper repository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-driver repository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""},
 	}
 
 	for _, tc := range PassTestCases {
@@ -48,7 +48,7 @@ func Test_getImageRegistries(t *testing.T) {
 	}
 
 	FailTestCases := []testCase{
-		{description: "Test repository not found", repository: "ndoesnotexist", registry: "registry.hub.docker.com", message: "Respository not found"},
+		{description: "Test repository not found", repository: "ndoesnotexist", registry: "registry.hub.docker.com", message: "repository not found"},
 	}
 
 	for _, tc := range FailTestCases {
@@ -71,13 +71,13 @@ func Test_checkImageInRegistry(t *testing.T) {
 	PassTestCases := []testCase{
 		{description: "Test nginx registry and version found.", message: "", imageRef: ImageReference{Repository: "rhel6.7", Registries: []string{"registry.access.redhat.com"}, Tag: "6.7", Sha: ""}},
 		{description: "Test nginx rhel6.7 and version found.", imageRef: ImageReference{Repository: "rhel6.7", Registries: []string{"registry.access.redhat.com"}, Tag: "6.7", Sha: ""}, message: ""},
-		{description: "Test rhel8/nginx-116 respository found.", imageRef: ImageReference{Repository: "rhel8/nginx-116", Registries: []string{"registry.access.redhat.com"}, Tag: "1-75", Sha: ""}, message: ""},
-		{description: "Test turbonomic/zookeeper respository and version found.", imageRef: ImageReference{Repository: "turbonomic/zookeeper", Registries: []string{"registry.connect.redhat.com"}, Tag: "8.1.2", Sha: ""}, message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-driver respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f"}, message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-plugin respository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}, message: ""},
-		{description: "Test postgresql-10-rhel7 respository and tag found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "latest", Sha: ""}, message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-plugin respository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:7c00bc76f91d456164f98375cd8932a0ec500c9dca1728368f3c1ccdbfd96e91"}, message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-driver respository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:667667c5907d0ad145e8518ca0f8cf013ca778d6738b028d1cd08103b1b64667"}, message: ""},
+		{description: "Test rhel8/nginx-116 repository found.", imageRef: ImageReference{Repository: "rhel8/nginx-116", Registries: []string{"registry.access.redhat.com"}, Tag: "1-75", Sha: ""}, message: ""},
+		{description: "Test turbonomic/zookeeper repository and version found.", imageRef: ImageReference{Repository: "turbonomic/zookeeper", Registries: []string{"registry.connect.redhat.com"}, Tag: "8.1.2", Sha: ""}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-driver repository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:fc17bb3e89d00b3eb0f50b3ea83aa75c52e43d8e56cf2e0f17475e934eeeeb5f"}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-plugin repository and sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:cf654987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b99298e6e"}, message: ""},
+		{description: "Test postgresql-10-rhel7 repository and tag found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "latest", Sha: ""}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-plugin repository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:7c00bc76f91d456164f98375cd8932a0ec500c9dca1728368f3c1ccdbfd96e91"}, message: ""},
+		{description: "Test cpopen/ibmcloud-object-storage-driver repository sha found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-driver", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:667667c5907d0ad145e8518ca0f8cf013ca778d6738b028d1cd08103b1b64667"}, message: ""},
 	}
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -88,9 +88,9 @@ func Test_checkImageInRegistry(t *testing.T) {
 	}
 
 	FailTestCases := []testCase{
-		{description: "Test postgresql-10-rhel7 version not found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "1.6.8", Sha: ""}, message: "Tag 1.6.8 not found"},
+		{description: "Test postgresql-10-rhel7 version not found", imageRef: ImageReference{Repository: "rhscl/postgresql-10-rhel7", Registries: []string{"registry.access.redhat.com"}, Tag: "1.6.8", Sha: ""}, message: "tag 1.6.8 not found"},
 		{description: "Test rhel6.7 registry not found", imageRef: ImageReference{Repository: "rhel6.7", Registries: []string{"registry.notfound.com"}, Tag: "7.8", Sha: ""}, message: "No images found for Registry/Repository: registry.notfound.com/rhel6.7"},
-		{description: "Test cpopen/ibmcloud-object-storage-plugin respository sha not found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:ffff4987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b9929ffff"}, message: "Digest sha256:ffff4987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b9929ffff not found"},
+		{description: "Test cpopen/ibmcloud-object-storage-plugin repository sha not found.", imageRef: ImageReference{Repository: "cpopen/ibmcloud-object-storage-plugin", Registries: []string{"icr.io"}, Tag: "", Sha: "sha256:ffff4987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b9929ffff"}, message: "digest sha256:ffff4987c38d048bc9e654f3928e9ce9a2a4fd47ce0283bb5f339c1b9929ffff not found"},
 	}
 
 	for _, tc := range FailTestCases {

--- a/internal/chartverifier/pyxis/pyxis_test.go
+++ b/internal/chartverifier/pyxis/pyxis_test.go
@@ -17,12 +17,12 @@
 package pyxis
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getImageRegistries(t *testing.T) {
-
 	type testCase struct {
 		description string
 		repository  string
@@ -36,7 +36,8 @@ func Test_getImageRegistries(t *testing.T) {
 		{description: "Test rhel8/nginx-116 respository", repository: "rhel8/nginx-116", registry: "registry.access.redhat.com", message: ""},
 		{description: "Test ibm/nginx respository", repository: "ibm/nginx", registry: "non_registry", message: ""},
 		{description: "Test turbonomic/zookeeper respository", repository: "turbonomic/zookeeper", registry: "registry.connect.redhat.com", message: ""},
-		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""}}
+		{description: "Test cpopen/ibmcloud-object-storage-driver respository", repository: "cpopen/ibmcloud-object-storage-driver", registry: "icr.io", message: ""},
+	}
 
 	for _, tc := range PassTestCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -58,11 +59,9 @@ func Test_getImageRegistries(t *testing.T) {
 			require.Contains(t, err.Error(), tc.message)
 		})
 	}
-
 }
 
 func Test_checkImageInRegistry(t *testing.T) {
-
 	type testCase struct {
 		description string
 		message     string

--- a/internal/chartverifier/utils/logger.go
+++ b/internal/chartverifier/utils/logger.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"io/ioutil"
@@ -15,6 +13,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 type VerifierLog struct {
@@ -27,13 +28,17 @@ type LogEntry struct {
 	Entry string `json:"Entry" yaml:"Entry"`
 }
 
-var CmdStdout io.Writer = os.Stdout
-var CmdStderr io.Writer = os.Stderr
+var (
+	CmdStdout io.Writer = os.Stdout
+	CmdStderr io.Writer = os.Stderr
+)
 
-var verifierlog VerifierLog
-var cmd *cobra.Command
-var stdoutFileName string
-var stderrFileName string
+var (
+	verifierlog    VerifierLog
+	cmd            *cobra.Command
+	stdoutFileName string
+	stderrFileName string
+)
 
 const outputDirectory string = "chartverifier"
 
@@ -72,7 +77,6 @@ func LogError(message string) {
 }
 
 func WriteLogs(log_format string) {
-
 	pruneLogFiles()
 
 	if len(verifierlog.Entries) > 0 && len(stderrFileName) > 0 {
@@ -95,7 +99,6 @@ func WriteLogs(log_format string) {
 		writeToFile(logOut, stderrFileName)
 	}
 	return
-
 }
 
 func WriteStdOut(output string) {
@@ -116,7 +119,6 @@ func writeToStdOut(output string) {
 }
 
 func writeToFile(output string, fileName string) bool {
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
@@ -126,7 +128,7 @@ func writeToFile(output string, fileName string) bool {
 	outputFile := path.Join(outputDir, fileName)
 	if _, err := os.Stat(outputDir); err != nil {
 		// #nosec G301
-		if err = os.MkdirAll(outputDir, 0777); err != nil {
+		if err = os.MkdirAll(outputDir, 0o777); err != nil {
 			LogError(fmt.Sprintf("error creating directory : %s : %s", outputDir, err))
 			return false
 		}
@@ -140,7 +142,7 @@ func writeToFile(output string, fileName string) bool {
 		LogError(fmt.Sprintf("Error removing existing file %s: %s", fileName, err))
 	}
 	// #nosec G304
-	if outfile, open_err := os.OpenFile(outputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600); open_err == nil {
+	if outfile, open_err := os.OpenFile(outputFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600); open_err == nil {
 		outfile.WriteString(output)
 		outfile.Close()
 		return true
@@ -181,7 +183,6 @@ func (fs *fileSorter) Less(i, j int) bool {
 }
 
 func pruneLogFiles() {
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
@@ -221,7 +222,6 @@ func pruneLogFiles() {
 		}
 
 	}
-
 }
 
 func getTimeStamp() string {

--- a/internal/chartverifier/utils/logger_test.go
+++ b/internal/chartverifier/utils/logger_test.go
@@ -3,15 +3,16 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 )
 
 func NewTestCmd(config *viper.Viper) *cobra.Command {
@@ -51,7 +52,6 @@ func NewTestCmd(config *viper.Viper) *cobra.Command {
 }
 
 func TestLogging(t *testing.T) {
-
 	t.Run("LogInfo, no logfile, should be no output", func(t *testing.T) {
 		tCmd := NewTestCmd(viper.New())
 		outBuf := bytes.NewBufferString("")
@@ -63,7 +63,6 @@ func TestLogging(t *testing.T) {
 
 		require.Empty(t, outBuf.String())
 		require.Empty(t, errBuf.String())
-
 	})
 
 	t.Run("LogInfo, set logfile, should be a logfile created", func(t *testing.T) {
@@ -85,7 +84,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Write to stdOut to a file", func(t *testing.T) {
@@ -105,7 +103,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure report is deleted")
 		})
-
 	})
 
 	t.Run("Write Error to stdError and file", func(t *testing.T) {
@@ -125,7 +122,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Write Warning to stdError and file", func(t *testing.T) {
@@ -145,7 +141,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log is deleted")
 		})
-
 	})
 
 	t.Run("Test log file pruning", func(t *testing.T) {
@@ -170,7 +165,6 @@ func TestLogging(t *testing.T) {
 		t.Cleanup(func() {
 			checkAndOrDeleteFiles("delete", "don't care just be sure log file are deleted")
 		})
-
 	})
 }
 

--- a/internal/chartverifier/utils/logger_test.go
+++ b/internal/chartverifier/utils/logger_test.go
@@ -59,7 +59,7 @@ func TestLogging(t *testing.T) {
 		errBuf := bytes.NewBufferString("")
 		CmdStderr = errBuf
 		tCmd.SetArgs([]string{"LogInfoOnly", "This should not be output"})
-		tCmd.Execute()
+		require.NoError(t, tCmd.Execute())
 
 		require.Empty(t, outBuf.String())
 		require.Empty(t, errBuf.String())
@@ -74,7 +74,7 @@ func TestLogging(t *testing.T) {
 
 		output := "This should be output in a log file"
 		tCmd.SetArgs([]string{"LogInfoFile", output})
-		tCmd.Execute()
+		require.NoError(t, tCmd.Execute())
 
 		require.Empty(t, outBuf.String())
 		require.Empty(t, errBuf.String())
@@ -94,7 +94,7 @@ func TestLogging(t *testing.T) {
 		CmdStderr = errBuf
 		output := "This should be output to file only"
 		tCmd.SetArgs([]string{"StdOutFile", output})
-		tCmd.Execute()
+		require.NoError(t, tCmd.Execute())
 
 		require.Empty(t, outBuf.String())
 		require.Empty(t, errBuf.String())
@@ -113,7 +113,7 @@ func TestLogging(t *testing.T) {
 		CmdStderr = errBuf
 		output := "This error should be output to stderr and log file"
 		tCmd.SetArgs([]string{"ErrorAndLog", output})
-		tCmd.Execute()
+		require.NoError(t, tCmd.Execute())
 
 		require.Empty(t, outBuf.String())
 		require.True(t, strings.Contains(errBuf.String(), output))
@@ -132,7 +132,7 @@ func TestLogging(t *testing.T) {
 		CmdStderr = errBuf
 		output := "This warning should be output to stderr and log file."
 		tCmd.SetArgs([]string{"WarningAndLog", output})
-		tCmd.Execute()
+		require.NoError(t, tCmd.Execute())
 
 		require.Empty(t, outBuf.String())
 		require.True(t, strings.Contains(errBuf.String(), output))
@@ -152,7 +152,7 @@ func TestLogging(t *testing.T) {
 
 		tCmd.SetArgs([]string{"testPrune"})
 		for i := 1; i <= 15; i++ {
-			tCmd.Execute()
+			require.NoError(t, tCmd.Execute())
 			numlogFiles := howManyLogFiles()
 			if i < 10 {
 				require.True(t, numlogFiles == i, fmt.Sprintf("expected %d logfile but found %d", i, numlogFiles))
@@ -182,7 +182,7 @@ func checkAndOrDeleteFiles(fileType string, expectedContent string) bool {
 		files, err := ioutil.ReadDir(logFilesPath)
 		if err != nil {
 			if fileType != "delete" {
-				fmt.Println(fmt.Sprintf("error reading log directory : %s : %s", logFilesPath, err))
+				fmt.Printf("error reading log directory : %s : %s\n", logFilesPath, err)
 				return false
 			}
 			return true
@@ -202,7 +202,7 @@ func checkAndOrDeleteFiles(fileType string, expectedContent string) bool {
 				if fileType != "delete" {
 					logfileContent, err := ioutil.ReadFile(filePath)
 					if err != nil {
-						fmt.Println(fmt.Sprintf("error reading file %s", err))
+						fmt.Printf("error reading file %s", err)
 						return false
 					}
 					if strings.Contains(string(logfileContent), expectedContent) {
@@ -220,14 +220,14 @@ func checkAndOrDeleteFiles(fileType string, expectedContent string) bool {
 func howManyLogFiles() int {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		fmt.Println(fmt.Sprintf("error getting current working directory : %s", err))
+		fmt.Printf("error getting current working directory : %s\n", err)
 		return 0
 	}
 	logFilesPath := path.Join(currentDir, outputDirectory)
 
 	files, err := ioutil.ReadDir(logFilesPath)
 	if err != nil {
-		fmt.Println(fmt.Sprintf("error reading log directory : %s : %s", logFilesPath, err))
+		fmt.Printf("error reading log directory : %s : %s\n", logFilesPath, err)
 		return 0
 	}
 	numLogFiles := 0


### PR DESCRIPTION
This PR should be styling everything else within the internal directory that another PR has not already styled.

There are a couple of noted exceptions here. I had to troubleshoot a bug that was caused by flipping a capital letter of an error to a lowercase letter, for example, and to prevent subtle bugs, I figured it best to leave that for another day. 