### PR TITLE
Allow for skipping tls verification with new cluster

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -136,7 +136,9 @@ jobs:
                   gpg --version
                   curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
                   if [ $GITHUB_REPOSITORY == "redhat-certification/chart-verifier" ]; then
-                    ./oc login --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
+                    # TODO: temporarily allow for skipping TLS verification as the new cluster uses local-only certificates
+                    # This if logic isn't removed to remind us to come back and swap this out when a valid cert is put in place.
+                    ./oc login --insecure-skip-tls-verify --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
                   else
                     ./oc login --insecure-skip-tls-verify --token=${{ secrets.CLUSTER_TOKEN }} --server=${API_SERVER}
                   fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /out/
 **/reports/
 __pycache__
+.vscode/


### PR DESCRIPTION
The new cluster is spun up using ACM and has local-only certs. Until we decide to build out a cert pipeline, we'll skip TLS verification for now, which should unblock the CI testing