### PR TITLE
Add option to skip cleanup after verification run

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -64,6 +64,8 @@ var (
 	reportToFile bool
 	// write an error log file
 	suppressErrorLog bool
+	// skip helm cleanup
+	skipCleanup bool
 	// distribution method is web-catalog-only.
 	webCatalogOnly bool
 	// client timeout
@@ -188,6 +190,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 			var runErr error
 			verifier, runErr = verifier.SetBoolean(apiverifier.WebCatalogOnly, webCatalogOnly).
 				SetBoolean(apiverifier.SuppressErrorLog, suppressErrorLog).
+				SetBoolean(apiverifier.SkipCleanup, skipCleanup).
 				SetDuration(apiverifier.Timeout, clientTimeout).
 				SetDuration(apiverifier.HelmInstallTimeout, helmInstallTimeout).
 				SetString(apiverifier.OpenshiftVersion, []string{openshiftVersionFlag}).
@@ -250,6 +253,7 @@ func NewVerifyCmd(config *viper.Viper) *cobra.Command {
 	cmd.Flags().DurationVar(&clientTimeout, "timeout", 30*time.Minute, "time to wait for completion of chart install and test")
 	cmd.Flags().BoolVarP(&reportToFile, "write-to-file", "w", false, "write report to ./chartverifier/report.yaml (default: stdout)")
 	cmd.Flags().BoolVarP(&suppressErrorLog, "suppress-error-log", "E", false, "suppress the error log (default: written to ./chartverifier/verifier-<timestamp>.log)")
+	cmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "c", false, "set this to skip resource cleanup after verifier run")
 	cmd.Flags().BoolVarP(&webCatalogOnly, "web-catalog-only", "W", false, "set this to indicate that the distribution method is web catalog only (default: false)")
 	cmd.Flags().StringVarP(&pgpPublicKeyFile, "pgp-public-key", "k", "", "file containing gpg public key of the key used to sign the chart")
 	cmd.Flags().DurationVar(&helmInstallTimeout, "helm-install-timeout", 5*time.Minute, "helm install timeout")

--- a/docs/helm-chart-api.md
+++ b/docs/helm-chart-api.md
@@ -45,6 +45,7 @@ type ApiVerifier interface {
   - ```WebCatalogOnly```
   - ```Provider Delivery``` (deprecated - replaced by ```WebCatalogOnly```)  
   - ```SuppressErrorLog```
+  - ```SkipCleanup```
     
 - SetDuration: Sets a duration flag. ```DurationKey``` values are defined in the verifier package and include:
   - ```Timeout```

--- a/internal/chartverifier/api/verifier.go
+++ b/internal/chartverifier/api/verifier.go
@@ -28,6 +28,7 @@ type RunOptions struct {
 	OpenShiftVersion   string
 	WebCatalogOnly     bool
 	SuppressErrorLog   bool
+	SkipCleanup        bool
 	ClientTimeout      time.Duration
 	HelmInstallTimeout time.Duration
 	ChartURI           string
@@ -62,6 +63,7 @@ func Run(options RunOptions) (*apireport.Report, error) {
 		SetToolVersion(options.APIVersion).
 		SetOpenShiftVersion(options.OpenShiftVersion).
 		SetWebCatalogOnly(options.WebCatalogOnly).
+		SetSkipCleanup(options.SkipCleanup).
 		SetTimeout(options.ClientTimeout).
 		SetHelmInstallTimeout(options.HelmInstallTimeout).
 		SetSettings(options.Settings).

--- a/internal/chartverifier/checks/registry.go
+++ b/internal/chartverifier/checks/registry.go
@@ -113,6 +113,8 @@ type CheckOptions struct {
 	PublicKeys []string
 	// helm install timeout
 	HelmInstallTimeout time.Duration
+	// skip helm cleanup
+	SkipCleanup bool
 }
 
 type CheckFunc func(options *CheckOptions) (Result, error)

--- a/internal/chartverifier/helmverifier.go
+++ b/internal/chartverifier/helmverifier.go
@@ -36,6 +36,7 @@ type VerifierBuilder interface {
 	SetToolVersion(string) VerifierBuilder
 	SetOpenShiftVersion(string) VerifierBuilder
 	SetWebCatalogOnly(bool) VerifierBuilder
+	SetSkipCleanup(bool) VerifierBuilder
 	SetTimeout(time.Duration) VerifierBuilder
 	SetPublicKeys([]string) VerifierBuilder
 	SetHelmInstallTimeout(time.Duration) VerifierBuilder

--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -72,6 +72,7 @@ type verifier struct {
 	profile            *profiles.Profile
 	openshiftVersion   string
 	webCatalogOnly     bool
+	skipCleanup        bool
 	timeout            time.Duration
 	helmInstallTimeout time.Duration
 	publicKeys         []string
@@ -122,6 +123,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 			AnnotationHolder:   &holder,
 			Timeout:            c.timeout,
 			HelmInstallTimeout: c.helmInstallTimeout,
+			SkipCleanup:        c.skipCleanup,
 			PublicKeys:         c.publicKeys,
 		})
 

--- a/internal/chartverifier/verifierbuilder.go
+++ b/internal/chartverifier/verifierbuilder.go
@@ -71,6 +71,7 @@ type verifierBuilder struct {
 	//nolint:unused
 	supportedOpenshiftVersions string
 	webCatalogOnly             bool
+	skipCleanup                bool
 	timeout                    time.Duration
 	publicKeys                 []string
 	helmInstallTimeout         time.Duration
@@ -123,6 +124,11 @@ func (b *verifierBuilder) SetOpenShiftVersion(version string) VerifierBuilder {
 
 func (b *verifierBuilder) SetWebCatalogOnly(webCatalogOnly bool) VerifierBuilder {
 	b.webCatalogOnly = webCatalogOnly
+	return b
+}
+
+func (b *verifierBuilder) SetSkipCleanup(skipCleanup bool) VerifierBuilder {
+	b.skipCleanup = skipCleanup
 	return b
 }
 
@@ -179,6 +185,7 @@ func (b *verifierBuilder) Build() (Verifier, error) {
 		profile:            profile,
 		openshiftVersion:   b.openshiftVersion,
 		webCatalogOnly:     b.webCatalogOnly,
+		skipCleanup:        b.skipCleanup,
 		timeout:            b.timeout,
 		helmInstallTimeout: b.helmInstallTimeout,
 		publicKeys:         b.publicKeys,

--- a/pkg/chartverifier/verifier/verifier.go
+++ b/pkg/chartverifier/verifier/verifier.go
@@ -70,6 +70,7 @@ const (
 	WebCatalogOnly   BooleanKey = "web-catalog-only"
 	ProviderDelivery BooleanKey = "provider-delivery" // Deprecated in 1.10
 	SuppressErrorLog BooleanKey = "suppress-error-log"
+	SkipCleanup      BooleanKey = "skip-cleanup"
 
 	Timeout            DurationKey = "timeout"
 	HelmInstallTimeout DurationKey = "helm-install-timeout"
@@ -100,7 +101,7 @@ var setValuesKeys = [...]ValuesKey{
 	ChartSetString,
 }
 
-var setBooleanKeys = [...]BooleanKey{WebCatalogOnly, SuppressErrorLog}
+var setBooleanKeys = [...]BooleanKey{WebCatalogOnly, SuppressErrorLog, SkipCleanup}
 
 var setDurationKeys = [...]DurationKey{Timeout, HelmInstallTimeout}
 
@@ -350,6 +351,10 @@ func (v *Verifier) Run(chartURI string) (APIVerifier, error) {
 		runOptions.SuppressErrorLog = booleanValue
 	}
 
+	if booleanValue, ok := v.Inputs.Flags.BooleanFlags[SkipCleanup]; ok {
+		runOptions.SkipCleanup = booleanValue
+	}
+
 	if durationValue, ok := v.Inputs.Flags.DurationFlags[Timeout]; ok {
 		runOptions.ClientTimeout = durationValue
 	}
@@ -397,6 +402,7 @@ func (v *Verifier) initialize() {
 	v.Inputs.Flags.BooleanFlags = make(map[BooleanKey]bool)
 	v.Inputs.Flags.BooleanFlags[WebCatalogOnly] = false
 	v.Inputs.Flags.BooleanFlags[SuppressErrorLog] = false
+	v.Inputs.Flags.BooleanFlags[SkipCleanup] = false
 	v.Inputs.Flags.DurationFlags = make(map[DurationKey]time.Duration)
 	v.Inputs.Flags.Checks = make(map[checks.CheckName]CheckStatus)
 


### PR DESCRIPTION
Skip cleanup flag added to command line and passed to the chart testing to skip resource cleanup after verification run

Closes #330 