### PR TITLE
Move runtime image to UBI9 from UBI8 to address GLIBC discrepancies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN go build -o ./out/chart-verifier main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 COPY --from=build /tmp/src/out/chart-verifier /app/chart-verifier
 


### PR DESCRIPTION
Similar to what was done to preflight after the golang 1.20  bump, chart-verifier currently fails at execution time because the glibc version at build time is different than what's provided at runtime. :roll_eyes: 