### PR TITLE
ensure setup-go workflow uses go.mod in the right location

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
             - name: Setup Go
               uses: actions/setup-go@v4
               with:
-                go-version-file: go.mod
+                go-version-file: ./chart-verifier/go.mod
                 
             - name: Ensure Modules
               working-directory: ./chart-verifier


### PR DESCRIPTION
We say it's in the same directory `go.mod`, but we clone to ./chart-verifier. Should probably change this some day.