### PR TITLE
Re-add removed clone of main during CI tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout
+            - name: Checkout main branch
+              uses: actions/checkout@v3
+            
+            - name: Checkout PR branch
               uses: actions/checkout@v3
               with:
                 ref: ${{ github.event.pull_request.head.ref }}
@@ -21,7 +24,7 @@ jobs:
             - name: Setup Go
               uses: actions/setup-go@v4
               with:
-                go-version-file: ./chart-verifier/go.mod
+                go-version-file: go.mod
                 
             - name: Ensure Modules
               working-directory: ./chart-verifier


### PR DESCRIPTION
The clone of the `main` branch was removed in the dep cleanup pr: https://github.com/redhat-certification/chart-verifier/pull/352

It was likely removed as a duplicate, but its existence is intentional, so this PR re-adds it at action version 3 (instead of 2), and reconfigured the setup-go action to use main's mod file.