### PR TITLE
Disable CGO on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp/src
 
 COPY . .
 
-RUN go build -o ./out/chart-verifier main.go
+RUN CGO_ENABLED=0 go build -o ./out/chart-verifier main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ fmt: install.gofumpt
 
 .PHONY: bin
 bin:
-	go build -o ./out/chart-verifier main.go
+	CGO_ENABLED=0 go build -o ./out/chart-verifier main.go
 
 .PHONY: lint
 lint: install.golangci-lint
@@ -41,7 +41,7 @@ lint: install.golangci-lint
 
 .PHONY: bin_win
 bin_win:
-	env GOOS=windows GOARCH=amd64 go build -o .\out\chart-verifier.exe main.go
+	env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o .\out\chart-verifier.exe main.go
 
 .PHONY: test
 test:


### PR DESCRIPTION
We don't seem to require CGO from what I can see. The golang builder image we use has a newer C toolchain than what's available in RHEL8. If disabling CGO isn't a problem, then this seems like the more compact route to take.

If this doesn't work out in the long term, we can just build from a RHEL8 golang builder image and that should also fix the problem.