### PR TITLE
Make dev releases prereleases and not drafts

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -61,8 +61,7 @@ jobs:
                 tag_name: ${{ env.DEV_RELEASE }}
                 body: "Development release created with each merge into the main branch."
                 files: ${{ steps.create-tarfile.outputs.tarball_full_name }}
+                prerelease: true
+                draft: false
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-


### PR DESCRIPTION
We randomly run into issues with our dev release, which is used in the certification pipeline's stage, development, and sandbox repositories, because the the release is marked as a draft.

This should that issue, and also specifies that the release should be marked as a prerelease which should address some UX concerns with the GitHub Release UI.

Fixes #355 