### PR TITLE
Ensure release creation only happens after release deletion is completed successfully

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -45,6 +45,7 @@ jobs:
                 ve1/bin/tar-file --release=${DEV_RELEASE}
 
             - name: Delete previous release and tag
+              name: delete-previous
               if: ${{ steps.create-tarfile.outcome == 'success' }}
               uses: dev-drprasad/delete-tag-and-release@v0.2.1
               with:
@@ -55,7 +56,7 @@ jobs:
 
             - name: Create the release
               id: create_release
-              if: ${{ always() && steps.create-tarfile.outcome == 'success' }}
+              if: ${{ steps.delete-previous.outcome == 'success' }}
               uses: softprops/action-gh-release@v1
               with:
                 tag_name: ${{ env.DEV_RELEASE }}


### PR DESCRIPTION
For whatever reason, we were still seeing draft releases even after #363 explicitly set the draft bool to false. 

In my testing of the workflow itself, I think what's happening is that the two jobs are running somewhat concurrently. The releaser action will make things a draft if an existing release exists so as to not clobber a release with changes. To that end, I think we if we wait for the deletion to complete, we should end up with a pre-release that isn't a draft.