### PR TITLE
Add commit ID to version output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp/src
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o ./out/chart-verifier main.go
+RUN make bin
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 IMAGE_BUILDER?=podman
 IMAGE_REPO?=quay.io/redhat-certification
 COMMIT_ID=$(shell git rev-parse --short HEAD)
+COMMIT_ID_LONG=$(shell git rev-parse HEAD)
 
 default: bin
 
@@ -33,7 +34,9 @@ fmt: install.gofumpt
 
 .PHONY: bin
 bin:
-	CGO_ENABLED=0 go build -o ./out/chart-verifier main.go
+	CGO_ENABLED=0 go build \
+		-ldflags "-X 'github.com/redhat-certification/chart-verifier/cmd.CommitIDLong=$(COMMIT_ID_LONG)'" \
+		-o ./out/chart-verifier main.go
 
 .PHONY: lint
 lint: install.golangci-lint
@@ -41,7 +44,9 @@ lint: install.golangci-lint
 
 .PHONY: bin_win
 bin_win:
-	env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o .\out\chart-verifier.exe main.go
+	env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build \
+		-ldflags "-X 'github.com/redhat-certification/chart-verifier/cmd.CommitIDLong=$(COMMIT_ID_LONG)'" \
+		-o .\out\chart-verifier.exe main.go
 
 .PHONY: test
 test:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,8 +12,25 @@ import (
 	apiversion "github.com/redhat-certification/chart-verifier/pkg/chartverifier/version"
 )
 
+// Print version and commit ID as json blob
+var asData bool
+
 func init() {
 	rootCmd.AddCommand(NewVersionCmd())
+}
+
+// CommitIDLong contains the commit ID the binary was build on. It is populated at build time by ldflags.
+// If you're running from a local debugger it will show an empty commit ID.
+var CommitIDLong string = "unknown"
+
+type VersionContext struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+var Version = VersionContext{
+	Version: apiversion.GetVersion(),
+	Commit:  CommitIDLong,
 }
 
 func NewVersionCmd() *cobra.Command {
@@ -24,10 +42,20 @@ func NewVersionCmd() *cobra.Command {
 			return runVersion(os.Stdout)
 		},
 	}
+	cmd.Flags().BoolVar(&asData, "as-data", false, "output the version and commit ID information in JSON format")
 	return cmd
 }
 
 func runVersion(out io.Writer) error {
-	fmt.Fprintf(out, "v%s\n", apiversion.GetVersion())
+	if asData {
+		marshalledVersion, err := json.Marshal(Version)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "%s\n", string(marshalledVersion))
+		return nil
+	}
+
+	fmt.Fprintf(out, "chart-verifier v%s <commit: %s>\n", apiversion.GetVersion(), CommitIDLong)
 	return nil
 }

--- a/scripts/src/buildandtest/buildandtest.py
+++ b/scripts/src/buildandtest/buildandtest.py
@@ -79,10 +79,10 @@ def test_image(image_id,chart,verifier_version):
         print(f'[ERROR] Chart verifier report version {report["metadata"]["tool"]["verifier-version"]} does not match  expected version: {verifier_version}')
         return False
 
-    docker_command = "version"
-    # sample output: v1.0.0
+    docker_command = "version --as-data"
+    # sample output: {"version":"1.12.0","commit":"4dcd90a273747df545df2c4414f091caa8b0eb3d"}
     out = client.containers.run(image_id, docker_command, stdin_open=True, tty=True, stderr=True)
-    if not out or out[1:] != verifier_version:
+    if not out or out["version"] != verifier_version:
         print(f"[ERROR] 'chart-verifier version' output {out} does not match expected version: {verifier_version}")
 
     print("[INFO] report:\n", report)
@@ -130,7 +130,7 @@ def main():
 
         if not args.build_only:
 
-            chart = {"url" : "https://github.com/redhat-certification/chart-verifier/blob/main/pkg/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true",
+            chart = {"url" : "https://github.com/redhat-certification/chart-verifier/blob/main/internal/chartverifier/checks/chart-0.1.0-v3.valid.tgz?raw=true",
                 "results":{"passed":"10","failed":"1"},
                 "metadata":{"vendorType":"partner","profileVersion":"v1.0"}}
 


### PR DESCRIPTION
- add a "build" make target, which injects the git commit ID using ldflags
- add the commit ID to the version output
- add the possibility to get the version and commit information in a JSON format


Example output:
```
[mgoerens@mgoerens-thinkpadp1gen3 chart-verifier]$ ./chart-verifier version
chart-verifier v1.12.0 <commit: 1c1d51406d0241cbf9683b8dd731eb4bcb706dec>
[mgoerens@mgoerens-thinkpadp1gen3 chart-verifier]$ ./chart-verifier version --as-data
{"version":"1.12.0","commit":"1c1d51406d0241cbf9683b8dd731eb4bcb706dec"}[mgoerens@mgoerens-thinkpadp1gen3 chart-verifier]$ 
```
