### PR TITLE
Use docker login and push instead of podman

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -107,16 +107,16 @@ jobs:
         id: build-image
         run: ve1/bin/build-and-test --image-name="quay.io/redhat-certification/chart-verifier" --sha-value=$DEV_RELEASE --build-only="True"}
 
-      - name: Login to Quay as Bot
+      - name: Login to Registry
         id: login-as-bot
+        uses: docker/login-action@v2
         if: ${{ steps.build-image.outcome == 'success'}}
-        uses: redhat-actions/podman-login@v1
         with:
-          username: ${{ secrets.QUAY_BOT_USERNAME }}
-          password: ${{ secrets.QUAY_BOT_TOKEN }}
-          registry: quay.io/redhat-certification
+          registry: quay.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push Image
         if: ${{ steps.login-as-bot.outcome == 'success' }}
         run: |
-          podman push quay.io/redhat-certification/chart-verifier:$DEV_RELEASE
+          docker push quay.io/redhat-certification/chart-verifier:$DEV_RELEASE


### PR DESCRIPTION
The `podman push` we're replacing was not able to access to image storage docker was using, so the push would fail.
https://github.com/redhat-certification/chart-verifier/actions/runs/5513080851/jobs/10050742461

In hindsight, the other action in this repo that does this _pulls_ first. Should have caught that.

At any rate, until we move away from the docker build scripts used in the main CI, the dev release should stay using the same script. This pushes the image using the docker-related GitHub Actions instead.