### PR TITLE
Use multiline parsing for run task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,7 +221,7 @@ jobs:
               # for it to complete before proceeding successfully.
               id: wait_for_image_build
               if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
-              run: 
+              run: |
                 expectedImage=quay.io/redhat-certification/chart-verifier:${{ steps.check_version_in_PR.outputs.PR_version }}
                 for i in {1..30}; do
                   s=60


### PR DESCRIPTION
This task is failing to run because the run logic didn't include the `|` to indicate multiline parsing should be used.