### PR TITLE
apply kubecontext setting to kubectl client

### DIFF
--- a/internal/tool/kubectl.go
+++ b/internal/tool/kubectl.go
@@ -171,7 +171,7 @@ func GetClientConfig(envSettings *cli.EnvSettings) clientcmd.ClientConfig {
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loadingRules,
-		&clientcmd.ConfigOverrides{})
+		&clientcmd.ConfigOverrides{CurrentContext: envSettings.KubeContext})
 }
 
 func getDeploymentsList(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {


### PR DESCRIPTION
Fix error with Gitlab agents not finding correct config. Essentially, the kube-context needed to be applied.

Closes #253 