### PR TITLE
Check images for an empty image string

### DIFF
--- a/internal/chartverifier/checks/checks.go
+++ b/internal/chartverifier/checks/checks.go
@@ -521,6 +521,12 @@ func certifyImages(r Result, opts *CheckOptions, registry string) Result {
 		r.SetResult(true, NoImagesToCertify)
 	} else {
 		for _, image := range images {
+			// skip to evaluate next image, if current image is an empty string
+			if strings.Trim(image, " ") == "" {
+				r.AddResult(false, "ImageCertify() = empty image found")
+				continue
+			}
+
 			err = nil
 			imageRef := parseImageReference(image)
 

--- a/internal/chartverifier/checks/checks_test.go
+++ b/internal/chartverifier/checks/checks_test.go
@@ -367,43 +367,92 @@ func TestHelmLint(t *testing.T) {
 }
 
 func TestImageCertify(t *testing.T) {
-	checkImages(t, ImagesAreCertified, false)
-
-	checkImages(t, ImagesAreCertified_V1_1, true)
+	checkImages(t)
 }
 
-func checkImages(t *testing.T, fn func(*CheckOptions) (Result, error), version1_1 bool) {
-	type testCase struct {
+func checkImages(t *testing.T) {
+	tests := []struct {
 		description string
 		uri         string
+		fn          CheckFunc
 		numErrors   int
 		numPasses   int
 		numSkips    int
+	}{
+		{
+			description: "chart-0.1.0-v3.valid.tgz check images passes",
+			uri:         "chart-0.1.0-v3.valid.tgz",
+			fn:          ImagesAreCertified,
+			numErrors:   0,
+			numPasses:   5,
+		},
+		{
+			description: "Helm check images fails",
+			uri:         "chart-0.1.0-v3.with-crd.tgz",
+			fn:          ImagesAreCertified,
+			numErrors:   4,
+			numPasses:   0,
+		},
+		{
+			description: "Helm check images fails",
+			uri:         "chart-0.1.0-v3.with-csi.tgz",
+			fn:          ImagesAreCertified,
+			numErrors:   2,
+			numPasses:   0,
+		},
+		{
+			description: "chart-0.1.0-v3.valid.tgz check images passes",
+			uri:         "chart-0.1.0-v3.valid.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   0,
+			numPasses:   5,
+			numSkips:    0,
+		},
+		{
+			description: "chart-0.1.0-v3.valid-skipped-images.tgz check images passes",
+			uri:         "chart-0.1.0-v3.valid-skipped-images.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   0,
+			numPasses:   3,
+			numSkips:    2,
+		},
+		{
+			description: "chart-0.1.0-v3.failed-skipped-images.tgz check images passes",
+			uri:         "chart-0.1.0-v3.failed-skipped-images.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   1,
+			numPasses:   0,
+			numSkips:    4,
+		},
+		{
+			description: "chart-0.1.0-v3.skipped-images.tgz check images passes",
+			uri:         "chart-0.1.0-v3.skipped-images.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   0,
+			numPasses:   0,
+			numSkips:    5,
+		},
+		{
+			description: "Helm check images fails",
+			uri:         "chart-0.1.0-v3.with-crd.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   4,
+			numPasses:   0,
+			numSkips:    0,
+		},
+		{
+			description: "Helm check images fails",
+			uri:         "chart-0.1.0-v3.with-csi.tgz",
+			fn:          ImagesAreCertified_V1_1,
+			numErrors:   2,
+			numPasses:   0,
+			numSkips:    0,
+		},
 	}
 
-	var testCases []testCase
-
-	if !version1_1 {
-		testCases = []testCase{
-			{description: "chart-0.1.0-v3.valid.tgz check images passes", uri: "chart-0.1.0-v3.valid.tgz", numErrors: 0, numPasses: 5},
-			{description: "Helm check images fails", uri: "chart-0.1.0-v3.with-crd.tgz", numErrors: 2, numPasses: 0},
-			{description: "Helm check images fails", uri: "chart-0.1.0-v3.with-csi.tgz", numErrors: 1, numPasses: 0},
-		}
-	} else {
-		testCases = []testCase{
-			{description: "chart-0.1.0-v3.valid.tgz check images passes", uri: "chart-0.1.0-v3.valid.tgz", numErrors: 0, numPasses: 5, numSkips: 0},
-			{description: "chart-0.1.0-v3.valid-skipped-images.tgz check images passes", uri: "chart-0.1.0-v3.valid-skipped-images.tgz", numErrors: 0, numPasses: 3, numSkips: 2},
-			{description: "chart-0.1.0-v3.failed-skipped-images.tgz check images passes", uri: "chart-0.1.0-v3.failed-skipped-images.tgz", numErrors: 1, numPasses: 0, numSkips: 4},
-			{description: "chart-0.1.0-v3.skipped-images.tgz check images passes", uri: "chart-0.1.0-v3.skipped-images.tgz", numErrors: 0, numPasses: 0, numSkips: 5},
-			{description: "Helm check images fails", uri: "chart-0.1.0-v3.with-crd.tgz", numErrors: 2, numPasses: 0, numSkips: 0},
-			{description: "Helm check images fails", uri: "chart-0.1.0-v3.with-csi.tgz", numErrors: 1, numPasses: 0, numSkips: 0},
-		}
-	}
-
-	for _, tc := range testCases {
+	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			config := viper.New()
-			r, err := fn(&CheckOptions{URI: tc.uri, ViperConfig: config, HelmEnvSettings: cli.New()})
+			r, err := tc.fn(&CheckOptions{URI: tc.uri, ViperConfig: viper.New(), HelmEnvSettings: cli.New()})
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.numErrors == 0 {

--- a/internal/chartverifier/checks/helm.go
+++ b/internal/chartverifier/checks/helm.go
@@ -218,13 +218,16 @@ func getImageReferences(chartURI string, vals map[string]interface{}, kubeVersio
 		return nil, err
 	}
 
-	return getImagesFromContent(txt), nil
+	return getImagesFromContent(txt)
 }
 
 // getImagesFromContent evaluates generated templates from
 // helm and extracts images which are returned in a slice
-func getImagesFromContent(content string) []string {
-	re := regexp.MustCompile(`\s+image\:\s+(?P<image>.*)\n`)
+func getImagesFromContent(content string) ([]string, error) {
+	re, err := regexp.Compile(`\s+image\:\s+(?P<image>.*)\n`)
+	if err != nil {
+		return nil, fmt.Errorf("error getting images; %v", err)
+	}
 	matches := re.FindAllStringSubmatch(content, -1)
 	imageMap := make(map[string]struct{})
 	for _, match := range matches {
@@ -239,7 +242,7 @@ func getImagesFromContent(content string) []string {
 		images = append(images, k)
 	}
 
-	return images
+	return images, nil
 }
 
 func getCacheDir(opts *CheckOptions) string {

--- a/internal/chartverifier/checks/helm_test.go
+++ b/internal/chartverifier/checks/helm_test.go
@@ -181,7 +181,7 @@ func TestLongLineTemplate(t *testing.T) {
 	content, err := os.ReadFile("templates/test-template.yaml")
 	require.NoError(t, err)
 
-	images, err := getImagesFromContent(string(content)), nil
+	images, err := getImagesFromContent(string(content))
 	require.NoError(t, err)
 
 	require.Equal(t, len(images), 2)
@@ -212,7 +212,8 @@ func TestGetImagesFromContent(t *testing.T) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
-		got := getImagesFromContent(test.content)
+		got, err := getImagesFromContent(test.content)
+		require.Nil(t, err)
 		if testing.Verbose() {
 			t.Logf("got %d images", len(got))
 		}

--- a/internal/chartverifier/checks/helm_test.go
+++ b/internal/chartverifier/checks/helm_test.go
@@ -180,7 +180,7 @@ func TestLongLineTemplate(t *testing.T) {
 	content, err := os.ReadFile("templates/test-template.yaml")
 	require.NoError(t, err)
 
-	images, err := getImagesFromContent(string(content))
+	images, err := getImagesFromContent(string(content)), nil
 	require.NoError(t, err)
 
 	require.Equal(t, len(images), 2)


### PR DESCRIPTION
Update the `getImagesFromContent` function to return all images, including empty ones.

In addition, when evaluating images received in certifyImages() function, skip evaluating registries for any empty images

These changes also have a performance improvement. Unlike the previous implementation of the function that evaluated each line of the generated helm templates for images.

```
chart-verifier/ (empty-image✗) $ go test -v  -run=^$ -bench=^BenchmarkGetImagesFromContent  github.com/redhat-certification/chart-verifier/internal/chartverifier/checks
goos: darwin
goarch: amd64
pkg: github.com/redhat-certification/chart-verifier/internal/chartverifier/checks
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkGetImagesFromContent
BenchmarkGetImagesFromContent-8      	    2780	    429554 ns/op
BenchmarkGetImagesFromContentAlt
BenchmarkGetImagesFromContentAlt-8   	   18494	     64014 ns/op
PASS
ok  	github.com/redhat-certification/chart-verifier/internal/chartverifier/checks	4.940s
chart-verifier/ (empty-image✗) $
```

Closes #347