### PR TITLE
Move container images creation to release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build, Test, Automerge and Tag
 # This workflow runs on all PRs that are targetting the main branch.
 #
 # It runs the test suite. If the PR is a release PR, it automerges and tags the main branch with
-# the corresonding new version. Finally, it retags the container image with latest.
+# the corresonding new version.
 
 on:
     pull_request_target:
@@ -225,39 +225,3 @@ jobs:
                 custom_tag: ${{ steps.check_version_in_PR.outputs.PR_version }}
                 tag_prefix: ""
                 commit_sha: ${{ steps.main_sha.outputs.origin_main_sha }}
-
-            - name: Wait for image build to complete
-              # Quay is configured to automatically build our image. This waits
-              # for it to complete before proceeding successfully.
-              id: wait_for_image_build
-              if: ${{ steps.check_version_updated.outputs.updated == 'true'}}
-              run: |
-                expectedImage=quay.io/redhat-certification/chart-verifier:${{ steps.check_version_in_PR.outputs.PR_version }}
-                for i in {1..30}; do
-                  s=60
-                  echo "Querying Quay for "${expectedImage}" in ${s} seconds..." 
-                  sleep $s
-                  skopeo inspect docker://"${expectedImage}" && echo "Image Found!" && exit 0
-                done
-                echo "ERR Image not found in allotted time."
-                exit 1           
-          
-            - name: Login to Quay as Bot
-              id: login_as_bot
-              if: ${{ steps.wait_for_image_build.outcome == 'success'}}
-              uses: redhat-actions/podman-login@v1
-              with:
-                username: ${{ secrets.QUAY_BOT_USERNAME }}
-                password: ${{ secrets.QUAY_BOT_TOKEN }}
-                registry: quay.io/redhat-certification
-
-            - name: Update latest tag
-              if: ${{ steps.login_as_bot.outcome == 'success'}}
-              id: update_latest_tag
-              # TODO: When we shift to a push-from-this-repo model (instead of Quay build model)
-              # we should transition this tag workflow to use the digest of the image built here in CI.
-              run: |
-                imageReference=quay.io/redhat-certification/chart-verifier
-                podman pull ${imageReference}:${{ steps.check_version_in_PR.outputs.PR_version }}
-                podman tag ${imageReference}:${{ steps.check_version_in_PR.outputs.PR_version }} ${imageReference}:latest
-                podman push ${imageReference}:latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,42 @@
+name: Create container image on main
+
+# This workflow builds a container image for each commit on the main branch.
+# The image is tagged with the (short) commit ID and "main", and pushed to Quay.
+
+on:
+    push:
+        branches:
+            - main
+jobs:
+    image:
+      name: Build and push container images
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get commit ID
+        id: get_commit_id
+        run: |
+          # Make the short commit ID available to the following steps.
+          COMMIT_ID=$(git rev-parse --short HEAD)
+          echo "commit_id=$COMMIT_ID" | tee -a $GITHUB_OUTPUT
+
+      - name: Build container images
+        id: build_container_images
+        run: |
+            # Build podman images locally
+            make build-image IMAGE_TAG=${{ steps.get_commit_id.outputs.commit_id }}
+            make build-image IMAGE_TAG=main
+
+      - name: Push to quay.io
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: chart-verifier
+          tags: |
+            ${{ steps.get_commit_id.outputs.commit_id }}
+            main
+          registry: quay.io/redhat-certification
+          username: ${{ secrets.QUAY_BOT_USERNAME }}
+          password: ${{ secrets.QUAY_BOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,8 @@ name: create release on new tags
 # Finally, as mentioned above, create a new tag (e.g. `git tag 1.12.2 && git push --tags`) to
 # recreate the release.
 #
-# This workflow builds the tarball, creates the Github release and attaches the tarball to it.
+# This workflow builds all release assets (the tarball and the container images), creates the
+# Github release and attaches the tarball to it.
 
 on:
   push:
@@ -88,3 +89,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build container images
+        id: build_container_images
+        run: |
+            # Build podman images locally
+            make build-image IMAGE_TAG=${{ steps.get_tag.outputs.release_version }}
+            make build-image IMAGE_TAG=latest
+
+      - name: Push to quay.io
+        id: push_to_quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: chart-verifier
+          tags: |
+            ${{ steps.get_tag.outputs.release_version }}
+            latest
+          registry: quay.io/redhat-certification
+          username: ${{ secrets.QUAY_BOT_USERNAME }}
+          password: ${{ secrets.QUAY_BOT_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMAGE_BUILDER?=podman
 IMAGE_REPO?=quay.io/redhat-certification
 COMMIT_ID=$(shell git rev-parse --short HEAD)
 COMMIT_ID_LONG=$(shell git rev-parse HEAD)
+IMAGE_TAG=$(COMMIT_ID)
 
 default: bin
 
@@ -52,9 +53,17 @@ bin_win:
 test:
 	go test -v ./...
 
+# Build the container image. Usage: make build-image IMAGE_TAG=my_tag
+# If IMAGE_TAG is not provided, use the COMMIT_ID
 .PHONY: build-image
 build-image:
-	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/chart-verifier:$(COMMIT_ID) .
+	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
+
+# Push the container image. Usage: make push-image IMAGE_TAG=my_tag
+# If IMAGE_TAG is not provided, use the COMMIT_ID
+.PHONY: push-image
+push-image:
+	$(IMAGE_BUILDER) push $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
 
 .PHONY: gosec
 gosec: install.gosec

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # **chart-verifier**: Rules based tool to certify Helm charts
 
-[![Docker Repository on Quay](https://quay.io/repository/redhat-certification/chart-verifier/status "Docker Repository on Quay")](https://quay.io/repository/redhat-certification/chart-verifier)
-
 The **chart-verifier** CLI tool allows you to validate the Helm chart against a configurable list of checks. The tool ensures that the Helm charts include the associated metadata and formatting, and are distribution ready.
 
 The tool allows users to validate a Helm chart URL and provides a report where each check has a `positive` or `negative` result. A negative result from a check indicates a problem with the chart, which needs correction. It ensures that the Helm chart works seamlessly on Red Hat OpenShift and can be submitted as a certified Helm chart in the [OpenShift Helm Repository](https://github.com/openshift-helm-charts).


### PR DESCRIPTION
This makes it possible to retrigger the entire release process, including all assets creation, by retagging the main branch.

Starting with this commit, build triggers on the
quay.io/redhat-certification/chart-verifier repo are no longer needed.

close #383