### PR TITLE
change actions/cache@v4 to v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
                 echo "date=$(/bin/date -u "+%Y%m%d")" | tee -a $GITHUB_OUTPUT
               shell: bash
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v3
               id: cache
               with:
                   path: ./chart-verifier/oc


### PR DESCRIPTION
Fix broken github workflow. Current workflow seems to be attempting to pull `actions/cache@v4` which can not be found.