### PR TITLE
Fix variable reference in dev release action

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -115,7 +115,7 @@ jobs:
         with:
           image: chart-verifier
           tags: |
-            $DEV_RELEASE
+            ${{ env.DEV_RELEASE }}
           registry: quay.io/redhat-certification
           username: ${{ secrets.QUAY_BOT_USERNAME }}
           password: ${{ secrets.QUAY_BOT_TOKEN }}


### PR DESCRIPTION
The dev image build was not correctly referring to a variable in the tag reference, so this adds the surrounding `${{ }}` which is what was missing