### PR TITLE
Remove unecessary steps in dev_release workflow

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -91,18 +91,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v4
-        with:
-            python-version: '3.9'
-
-      - name: Set up Python scripts
-        run: |
-          # set up python requirements and scripts on PR branch
-          python3 -m venv ve1
-          cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
-          cd scripts && ../ve1/bin/python3 setup.py install && cd ..
-
       - name: Build container images
         id: build_container_images
         run: |


### PR DESCRIPTION
Python steps are not used anymore in this workflow, hence those setup steps can now be removed.