### PR TITLE
Expire commit container images after 1 week

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,8 +25,9 @@ jobs:
       - name: Build container images
         id: build_container_images
         run: |
+            podman version
             # Build podman images locally
-            make build-image IMAGE_TAG=${{ steps.get_commit_id.outputs.commit_id }}
+            make build-image IMAGE_TAG=${{ steps.get_commit_id.outputs.commit_id }} QUAY_EXPIRE_AFTER=1w
             make build-image IMAGE_TAG=main
 
       - name: Push to quay.io

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMAGE_REPO?=quay.io/redhat-certification
 COMMIT_ID=$(shell git rev-parse --short HEAD)
 COMMIT_ID_LONG=$(shell git rev-parse HEAD)
 IMAGE_TAG=$(COMMIT_ID)
+QUAY_EXPIRE_AFTER="never"
 
 default: bin
 
@@ -57,13 +58,18 @@ test:
 # If IMAGE_TAG is not provided, use the COMMIT_ID
 .PHONY: build-image
 build-image:
-	$(IMAGE_BUILDER) build -t $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
+	# TODO: Adding --no-cache option as a workaround to https://github.com/containers/buildah/issues/4632
+	# This can be removed as soon as we can ensure that the ubuntu-latest runner image uses podman=>4.6.0
+	$(IMAGE_BUILDER) build \
+		--no-cache \
+		--label quay.expires-after=$(QUAY_EXPIRE_AFTER) \
+		-t $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
 
 # Push the container image. Usage: make push-image IMAGE_TAG=my_tag
 # If IMAGE_TAG is not provided, use the COMMIT_ID
 .PHONY: push-image
 push-image:
-	$(IMAGE_BUILDER) push $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
+	$(IMAGE_BUILDER) push $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG)
 
 .PHONY: gosec
 gosec: install.gosec


### PR DESCRIPTION
Prior to podman 4.6.0, there is a bug that would cause the expiration tag to be added to the "main" container image as well in the build.yaml workflow. See the buildah bug report:
https://github.com/containers/buildah/issues/4632

As a workaround, the --no-cache flag is used to build container images with the "build-image" make target.

This workaround, can be removed when we use a runner image that has podman>=4.6.0. Currently, the ubuntu-latest runner image we use has 3.4.4.

close #397