### PR TITLE
Adding support for daemonSet and statefulSet resources in charts

### DIFF
--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -235,7 +235,7 @@ func testRelease(
 	release, namespace, releaseSelector string,
 	cleanupHelmTests bool,
 ) error {
-	if err := kubectl.WaitForDeployments(ctx, namespace, releaseSelector); err != nil {
+	if err := kubectl.WaitForWorkloadResources(ctx, namespace, releaseSelector); err != nil {
 		return err
 	}
 	if err := helm.Test(ctx, namespace, release); err != nil {

--- a/internal/tool/kubectl.go
+++ b/internal/tool/kubectl.go
@@ -43,10 +43,6 @@ type versionMapping struct {
 	OcpVersion  string `yaml:"ocp-version"`
 }
 
-type deploymentNotReady struct {
-	Name        string
-	Unavailable int32
-}
 type workloadNotReady struct {
 	ResourceType string
 	Name         string
@@ -100,6 +96,7 @@ func NewKubectl(kubeConfig clientcmd.ClientConfig) (*Kubectl, error) {
 
 	return kubectl, nil
 }
+
 func (k Kubectl) WaitForWorkloadResources(context context.Context, namespace string, selector string) error {
 	deadline, _ := context.Deadline()
 	unavailableWorkloadResources := []workloadNotReady{{Name: "none", Unavailable: 1}}
@@ -214,6 +211,7 @@ func getDeploymentsList(k Kubectl, context context.Context, namespace string, se
 	}
 	return list.Items, err
 }
+
 func getStatefulSetsList(k Kubectl, context context.Context, namespace string, selector string) ([]v1.StatefulSet, error) {
 	list, err := k.clientset.AppsV1().StatefulSets(namespace).List(context, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
@@ -221,6 +219,7 @@ func getStatefulSetsList(k Kubectl, context context.Context, namespace string, s
 	}
 	return list.Items, err
 }
+
 func getDaemonSetsList(k Kubectl, context context.Context, namespace string, selector string) ([]v1.DaemonSet, error) {
 	list, err := k.clientset.AppsV1().DaemonSets(namespace).List(context, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {

--- a/internal/tool/kubectl_test.go
+++ b/internal/tool/kubectl_test.go
@@ -321,7 +321,7 @@ func TestTimeExpirationGetDeploymentsFailure(t *testing.T) {
 	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Time out retrying after")
-	require.Contains(t, err.Error(), "error getting deployments from namespace")
+	require.Contains(t, err.Error(), "error getting Deployment from namespace")
 	require.Contains(t, err.Error(), "pretend error getting deployment list")
 }
 

--- a/internal/tool/kubectl_test.go
+++ b/internal/tool/kubectl_test.go
@@ -154,9 +154,11 @@ var testStatefulSets = []v1.StatefulSet{
 	},
 }
 
-var DeploymentList1 []v1.Deployment
-var DaemonSetList1 []v1.DaemonSet
-var StatefulSetList1 []v1.StatefulSet
+var (
+	DeploymentList1  []v1.Deployment
+	DaemonSetList1   []v1.DaemonSet
+	StatefulSetList1 []v1.StatefulSet
+)
 
 func TestGetDeploymentList(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -164,6 +166,7 @@ func TestGetDeploymentList(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 	_, err := clientset.AppsV1().Deployments("").Create(ctx, &testDeployments[0], metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	kubectl := Kubectl{clientset: clientset}
 	deps, err := getDeploymentsList(kubectl, ctx, "", "")
@@ -171,7 +174,6 @@ func TestGetDeploymentList(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(deps))
 	require.Equal(t, testDeployments[0], deps[0])
-
 }
 
 func TestGetDaemonSetList(t *testing.T) {
@@ -180,6 +182,7 @@ func TestGetDaemonSetList(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 	_, err := clientset.AppsV1().DaemonSets("").Create(ctx, &testDaemonSets[0], metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	kubectl := Kubectl{clientset: clientset}
 	daemons, err := getDaemonSetsList(kubectl, ctx, "", "")
@@ -187,7 +190,6 @@ func TestGetDaemonSetList(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(daemons))
 	require.Equal(t, testDaemonSets[0], daemons[0])
-
 }
 
 func TestGetStatefulSetList(t *testing.T) {
@@ -196,6 +198,7 @@ func TestGetStatefulSetList(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 	_, err := clientset.AppsV1().StatefulSets("").Create(ctx, &testStatefulSets[0], metav1.CreateOptions{})
+	require.NoError(t, err)
 
 	kubectl := Kubectl{clientset: clientset}
 	sts, err := getStatefulSetsList(kubectl, ctx, "", "")
@@ -203,7 +206,6 @@ func TestGetStatefulSetList(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sts))
 	require.Equal(t, testStatefulSets[0], sts[0])
-
 }
 
 func TestWaitForWorkloadResources(t *testing.T) {
@@ -288,7 +290,6 @@ func TestBadToGoodWaitForStatefulSets(t *testing.T) {
 	k := new(Kubectl)
 	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.NoError(t, err)
-
 }
 
 func TestTimeExpirationWaitingForWorkloadResources(t *testing.T) {
@@ -345,6 +346,7 @@ func daemonSetTestListGood(k Kubectl, context context.Context, namespace string,
 	}
 	return DaemonSetList1, nil
 }
+
 func statefulSetTestListGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.StatefulSet, error) {
 	fmt.Println("statefulSetSetTestListGood called")
 	for index := 0; index < len(testDaemonSets); index++ {
@@ -364,9 +366,11 @@ func deploymentTestListBad(k Kubectl, context context.Context, namespace string,
 	return nil, errors.New("pretend error getting deployment list")
 }
 
-var deploymentErrorSent = false
-var daemonSetErrorSent = false
-var statefulSetErrorSent = false
+var (
+	deploymentErrorSent  = false
+	daemonSetErrorSent   = false
+	statefulSetErrorSent = false
+)
 
 func deploymentTestListBadToGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
 	if !deploymentErrorSent {

--- a/internal/tool/kubectl_test.go
+++ b/internal/tool/kubectl_test.go
@@ -124,18 +124,106 @@ var testDeployments = []v1.Deployment{
 	},
 }
 
-var DeploymentList1 []v1.Deployment
+var testDaemonSets = []v1.DaemonSet{
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test0"},
+		Status:     v1.DaemonSetStatus{NumberUnavailable: 1},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+		Status:     v1.DaemonSetStatus{NumberUnavailable: 2},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test2"},
+		Status:     v1.DaemonSetStatus{NumberUnavailable: 3},
+	},
+}
 
-func TestWaitForDeployments(t *testing.T) {
+var testStatefulSets = []v1.StatefulSet{
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test0"},
+		Status:     v1.StatefulSetStatus{Replicas: 1, AvailableReplicas: 0},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test1"},
+		Status:     v1.StatefulSetStatus{Replicas: 2, AvailableReplicas: 0},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{Name: "test0"},
+		Status:     v1.StatefulSetStatus{Replicas: 3, AvailableReplicas: 0},
+	},
+}
+
+var DeploymentList1 []v1.Deployment
+var DaemonSetList1 []v1.DaemonSet
+var StatefulSetList1 []v1.StatefulSet
+
+func TestGetDeploymentList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientset := fake.NewSimpleClientset()
+	_, err := clientset.AppsV1().Deployments("").Create(ctx, &testDeployments[0], metav1.CreateOptions{})
+
+	kubectl := Kubectl{clientset: clientset}
+	deps, err := getDeploymentsList(kubectl, ctx, "", "")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(deps))
+	require.Equal(t, testDeployments[0], deps[0])
+
+}
+
+func TestGetDaemonSetList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientset := fake.NewSimpleClientset()
+	_, err := clientset.AppsV1().DaemonSets("").Create(ctx, &testDaemonSets[0], metav1.CreateOptions{})
+
+	kubectl := Kubectl{clientset: clientset}
+	daemons, err := getDaemonSetsList(kubectl, ctx, "", "")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(daemons))
+	require.Equal(t, testDaemonSets[0], daemons[0])
+
+}
+
+func TestGetStatefulSetList(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	clientset := fake.NewSimpleClientset()
+	_, err := clientset.AppsV1().StatefulSets("").Create(ctx, &testStatefulSets[0], metav1.CreateOptions{})
+
+	kubectl := Kubectl{clientset: clientset}
+	sts, err := getStatefulSetsList(kubectl, ctx, "", "")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sts))
+	require.Equal(t, testStatefulSets[0], sts[0])
+
+}
+
+func TestWaitForWorkloadResources(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	listDeployments = deploymentTestListGood
+	listDaemonSets = daemonSetTestListGood
+	listStatefulSets = statefulSetTestListGood
+
 	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	DaemonSetList1 = make([]v1.DaemonSet, len(testDaemonSets))
+	StatefulSetList1 = make([]v1.StatefulSet, len(testStatefulSets))
+
 	copy(DeploymentList1, testDeployments)
+	copy(DaemonSetList1, testDaemonSets)
+	copy(StatefulSetList1, testStatefulSets)
 
 	k := new(Kubectl)
-	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.NoError(t, err)
 }
 
@@ -147,12 +235,63 @@ func TestBadToGoodWaitForDeployments(t *testing.T) {
 	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
 	copy(DeploymentList1, testDeployments)
 
+	listDaemonSets = daemonSetTestListGood
+	DaemonSetList1 = make([]v1.DaemonSet, len(testDaemonSets))
+	copy(DaemonSetList1, testDaemonSets)
+
+	listStatefulSets = statefulSetTestListGood
+	StatefulSetList1 = make([]v1.StatefulSet, len(testStatefulSets))
+	copy(StatefulSetList1, testStatefulSets)
+
 	k := new(Kubectl)
-	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.NoError(t, err)
 }
 
-func TestTimeExpirationWaitingForDeployments(t *testing.T) {
+func TestBadToGoodWaitForDaemonSets(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListGood
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	listDaemonSets = daemonSetTestListBadToGood
+	DaemonSetList1 = make([]v1.DaemonSet, len(testDaemonSets))
+	copy(DaemonSetList1, testDaemonSets)
+
+	listStatefulSets = statefulSetTestListGood
+	StatefulSetList1 = make([]v1.StatefulSet, len(testStatefulSets))
+	copy(StatefulSetList1, testStatefulSets)
+
+	k := new(Kubectl)
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
+	require.NoError(t, err)
+}
+
+func TestBadToGoodWaitForStatefulSets(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listDeployments = deploymentTestListGood
+	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
+	copy(DeploymentList1, testDeployments)
+
+	listDaemonSets = daemonSetTestListGood
+	DaemonSetList1 = make([]v1.DaemonSet, len(testDaemonSets))
+	copy(DaemonSetList1, testDaemonSets)
+
+	listStatefulSets = statefulSetTestListBadToGood
+	StatefulSetList1 = make([]v1.StatefulSet, len(testStatefulSets))
+	copy(StatefulSetList1, testStatefulSets)
+
+	k := new(Kubectl)
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
+	require.NoError(t, err)
+
+}
+
+func TestTimeExpirationWaitingForWorkloadResources(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
@@ -160,10 +299,13 @@ func TestTimeExpirationWaitingForDeployments(t *testing.T) {
 	DeploymentList1 = make([]v1.Deployment, len(testDeployments))
 	copy(DeploymentList1, testDeployments)
 
+	listDaemonSets = daemonSetTestListEmpty
+	listStatefulSets = statefulSetTestListEmpty
+
 	k := new(Kubectl)
-	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "error unavailable deployments, timeout has expired,")
+	require.Contains(t, err.Error(), "error unavailable workload resources, timeout has expired,")
 }
 
 func TestTimeExpirationGetDeploymentsFailure(t *testing.T) {
@@ -175,7 +317,7 @@ func TestTimeExpirationGetDeploymentsFailure(t *testing.T) {
 	copy(DeploymentList1, testDeployments)
 
 	k := new(Kubectl)
-	err := k.WaitForDeployments(ctx, "testNameSpace", "selector")
+	err := k.WaitForWorkloadResources(ctx, "testNameSpace", "selector")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Time out retrying after")
 	require.Contains(t, err.Error(), "error getting deployments from namespace")
@@ -193,19 +335,73 @@ func deploymentTestListGood(k Kubectl, context context.Context, namespace string
 	return DeploymentList1, nil
 }
 
+func daemonSetTestListGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.DaemonSet, error) {
+	fmt.Println("daemonSetTestListGood called")
+	for index := 0; index < len(testDaemonSets); index++ {
+		if DaemonSetList1[index].Status.NumberUnavailable > 0 {
+			DaemonSetList1[index].Status.NumberUnavailable--
+			fmt.Printf("NumberUnavailable set to %d for daemonset %s\n", DaemonSetList1[index].Status.NumberUnavailable, DaemonSetList1[index].Name)
+		}
+	}
+	return DaemonSetList1, nil
+}
+func statefulSetTestListGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.StatefulSet, error) {
+	fmt.Println("statefulSetSetTestListGood called")
+	for index := 0; index < len(testDaemonSets); index++ {
+		unavailableReplicas := StatefulSetList1[index].Status.Replicas - StatefulSetList1[index].Status.AvailableReplicas
+		if unavailableReplicas > 0 {
+			StatefulSetList1[index].Status.AvailableReplicas++
+			unavailableReplicas = StatefulSetList1[index].Status.Replicas - StatefulSetList1[index].Status.AvailableReplicas
+
+			fmt.Printf("Unavailable Replicas set to %d for statefulset %s\n", unavailableReplicas, StatefulSetList1[index].Name)
+		}
+	}
+	return StatefulSetList1, nil
+}
+
 func deploymentTestListBad(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
 	fmt.Println("deploymentTestListBad called")
 	return nil, errors.New("pretend error getting deployment list")
 }
 
-var errorSent = false
+var deploymentErrorSent = false
+var daemonSetErrorSent = false
+var statefulSetErrorSent = false
 
 func deploymentTestListBadToGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.Deployment, error) {
-	if !errorSent {
-		fmt.Println("deploymentTestListBadToGoodToBad bad path")
-		errorSent = true
+	if !deploymentErrorSent {
+		fmt.Println("deploymentTestListBadToGood bad path")
+		deploymentErrorSent = true
 		return nil, errors.New("pretend error getting deployment list")
 	}
-	fmt.Println("deploymentTestListBadToGoodToBad good path")
+	fmt.Println("deploymentTestListBadToGood good path")
 	return deploymentTestListGood(k, context, namespace, selector)
+}
+
+func daemonSetTestListBadToGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.DaemonSet, error) {
+	if !daemonSetErrorSent {
+		fmt.Println("daemonSetTestListBadToGood bad path")
+		daemonSetErrorSent = true
+		return nil, errors.New("pretend error getting daemonSet list")
+	}
+	fmt.Println("deploymentTestListBadToGood good path")
+	return daemonSetTestListGood(k, context, namespace, selector)
+}
+
+func statefulSetTestListBadToGood(k Kubectl, context context.Context, namespace string, selector string) ([]v1.StatefulSet, error) {
+	if !statefulSetErrorSent {
+		fmt.Println("statefulSetTestListBadToGood bad path")
+		statefulSetErrorSent = true
+		return nil, errors.New("pretend error getting statefulSet list")
+	}
+	fmt.Println("statefulSetTestListBadToGood good path")
+	return statefulSetTestListGood(k, context, namespace, selector)
+}
+
+func daemonSetTestListEmpty(k Kubectl, context context.Context, namespace string, selector string) ([]v1.DaemonSet, error) {
+	return []v1.DaemonSet{}, nil
+}
+
+func statefulSetTestListEmpty(k Kubectl, context context.Context, namespace string, selector string) ([]v1.StatefulSet, error) {
+	return []v1.StatefulSet{}, nil
 }


### PR DESCRIPTION
Update waitForDeployments to waitForWorkloads and add the ability to wait for DaemonSets and StatefulSets.
Add tests for this new feature and increase code coverage

Closes #286 