### PR TITLE
remove output directory from file list for digest

### DIFF
--- a/internal/chartverifier/utils/logger.go
+++ b/internal/chartverifier/utils/logger.go
@@ -39,7 +39,7 @@ var (
 	stderrFileName string
 )
 
-const outputDirectory string = "chartverifier"
+const OutputDirectory string = "chartverifier"
 
 func InitLog(cobraCmd *cobra.Command, stdFilename string, suppressErrorLog bool) {
 	cmd = cobraCmd
@@ -123,7 +123,7 @@ func writeToFile(output string, fileName string) bool {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
 		return false
 	}
-	outputDir := path.Join(currentDir, outputDirectory)
+	outputDir := path.Join(currentDir, OutputDirectory)
 	outputFile := path.Join(outputDir, fileName)
 	if _, err := os.Stat(outputDir); err != nil {
 		// #nosec G301
@@ -200,7 +200,7 @@ func pruneLogFiles() {
 		LogError(fmt.Sprintf("error getting current working directory : %s", err))
 		return
 	}
-	logFilesPath := path.Join(currentDir, outputDirectory)
+	logFilesPath := path.Join(currentDir, OutputDirectory)
 
 	if _, err := os.Stat(logFilesPath); err != nil {
 		return

--- a/internal/chartverifier/utils/logger_test.go
+++ b/internal/chartverifier/utils/logger_test.go
@@ -176,7 +176,7 @@ func checkAndOrDeleteFiles(fileType string, expectedContent string) bool {
 				"ror getting current working directory : %s", err))
 			return false
 		}
-		logFilesPath := path.Join(currentDir, outputDirectory)
+		logFilesPath := path.Join(currentDir, OutputDirectory)
 
 		files, err := os.ReadDir(logFilesPath)
 		if err != nil {
@@ -222,7 +222,7 @@ func howManyLogFiles() int {
 		fmt.Printf("error getting current working directory : %s\n", err)
 		return 0
 	}
-	logFilesPath := path.Join(currentDir, outputDirectory)
+	logFilesPath := path.Join(currentDir, OutputDirectory)
 
 	files, err := os.ReadDir(logFilesPath)
 	if err != nil {


### PR DESCRIPTION
Added a filter function to remove output files created by chart-verifier from the list of files used to calculate the sha256 digest

Closes #316 