### PR TITLE
Partition out Golang and Python linting and style tasks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-# Recommend matching the black line length (default 88),
-# rather than using the flake8 default of 79:
-max-line-length = 88
-extend-ignore =
-    # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,14 +35,6 @@ jobs:
               working-directory: ./chart-verifier
               run: make tidy
 
-            - name: Ensure Formatting
-              working-directory: ./chart-verifier
-              run: make fmt
-
-            - name: Run Linters
-              working-directory: ./chart-verifier
-              run: make lint
-
             - name: Build Binary
               working-directory: ./chart-verifier
               run: make bin
@@ -70,15 +62,6 @@ jobs:
                 python3 -m venv ve1
                 cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
                 cd scripts && ../ve1/bin/python3 setup.py install && cd ..
-
-            - name: Run flake8
-              working-directory: ./chart-verifier
-              run: |
-                python3 -m venv ve_flake8
-                source ve_flake8/bin/activate
-                pip3 install flake8
-                flake8 scripts/
-                flake8 tests/
 
             - name: Check if only release file in PR
               working-directory: ./chart-verifier

--- a/.github/workflows/golang-style.yml
+++ b/.github/workflows/golang-style.yml
@@ -1,0 +1,30 @@
+name: Golang Style
+
+on:
+  pull_request:
+    paths:
+    - '**.go'
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
+    - name: Ensure Modules
+      run: make tidy
+
+    - name: Ensure Formatting
+      run: make fmt
+
+    - name: Run Linters
+      run: make lint
+
+    - name: Build Binary
+      run: make bin

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -1,0 +1,31 @@
+name: Python Style
+
+on:
+  pull_request:
+    paths:
+    # Only trigger on changes to Python source.
+    - 'scripts/**.py'
+    - 'tests/**.py'
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.x Part 1
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+
+    - name: Install style tooling
+      run: make venv.codestyle
+
+    - name: Run formatter
+      run: make py.ci.format
+
+      # Temporarily auto-pass linting until we are able to manually review and
+      # address.
+    - name: Run linter
+      run: make py.lint

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ coverage.out
 
 # omit generated reports
 report-info.*
+
+# ignore python venvs
+ve1/
+venv.*/

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,63 @@ push-image:
 gosec: install.gosec
 	$(GOSEC) -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir tests ./...
 
-### Developer Tooling Installation
+### Python Specific Targets
+PY_BIN ?= python3
 
+# The virtualenv containing code style tools.
+VENV_CODESTYLE = venv.codestyle
+VENV_CODESTYLE_BIN = $(VENV_CODESTYLE)/bin
+
+# The virtualenv containing our CI scripts
+VENV_TOOLS = venv.tools
+VENV_TOOLS_BIN = $(VENV_TOOLS)/bin
+
+# This is what we pass to git ls-files.
+LS_FILES_INPUT_STR ?= 'scripts/src/*.py' 'tests/*.py'
+
+# The same as format, but will throw a non-zero exit code
+# if the formatter had to make changes.
+.PHONY: py.ci.format
+py.ci.format: py.format
+	git diff --exit-code
+
+venv.codestyle:
+	$(MAKE) venv.codestyle.always-reinstall
+
+# This target will always install the codestyle venv.
+# Useful for development cases.
+.PHONY: venv.codestyle.always-reinstall
+venv.codestyle.always-reinstall:
+	$(PY_BIN) -m venv $(VENV_CODESTYLE)
+	./$(VENV_CODESTYLE_BIN)/pip install --upgrade \
+		black \
+		ruff
+
+.PHONY: py.format
+py.format: venv.codestyle
+	./$(VENV_CODESTYLE_BIN)/black \
+		--verbose \
+		$$(git ls-files $(LS_FILES_INPUT_STR))
+
+.PHONY: py.lint
+py.lint: venv.codestyle
+	./$(VENV_CODESTYLE_BIN)/ruff \
+		check \
+		$$(git ls-files $(LS_FILES_INPUT_STR))
+
+venv.tools:
+	$(MAKE) venv.tools.always-reinstall
+
+# This target will always install the tools at the venv.
+# Useful for development cases.
+.PHONY: venv.tools.always-reinstall
+venv.tools.always-reinstall:
+	$(PY_BIN) -m venv $(VENV_TOOLS)
+	./$(VENV_TOOLS_BIN)/pip install -r requirements.txt
+	./$(VENV_TOOLS_BIN)/python setup.py install
+
+
+### Developer Tooling Installation
 # gosec
 GOSEC = $(shell pwd)/out/gosec
 GOSEC_VERSION ?= latest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+ignore = [
+    "E203" # https://github.com/PyCQA/pycodestyle/issues/373
+] 


### PR DESCRIPTION
This PR moves our style and formatting enforcement to separate jobs.

Tasks related to formatting/style that are not required to run the build workflows are removed from their original workflows and isolated here to run asynchronously from other CI.

This PR also transitions to use ruff instead of flake8 (remaining consistent with the helm cert pipeline)