### PR TITLE
Use the go.mod from the PR to setup Golang

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
             - name: Setup Go
               uses: actions/setup-go@v4
               with:
-                go-version-file: go.mod
+                go-version-file: ./chart-verifier/go.mod
                 
             - name: Ensure Modules
               working-directory: ./chart-verifier


### PR DESCRIPTION
We use the go.mod file in main instead of from the PR, and so PRs that bump the golang version may fail to run.
This PR fixes that.