### PR TITLE
Release 1.13.2

### DIFF
--- a/pkg/chartverifier/version/version_info.json
+++ b/pkg/chartverifier/version/version_info.json
@@ -1,11 +1,9 @@
 {
-    "version": "1.13.1",
+    "version": "1.13.2",
     "quay-image":  "quay.io/redhat-certification/chart-verifier",
     "release-info": [
         "<ul>",
-        "<li>Add Support for RHOCP 4.14 (#413) by @vikasmulaje</li>",
-        "<li>Use the go.mod from the PR to setup Golang (#415) by @komish</li>",
-        "<li>Bump Golang to v1.21 (#414) by @komish</li>",
+        "<li>bump getocprange to include 4.14 support (#417) by @komish</li>",
         "</ul>"
     ]
 }


### PR DESCRIPTION
We needed to bump a dependency to properly include 4.14 support, and the 1.13.1 release did not include that change. That's done here.