### PR TITLE
Removing unused variable setOverridesFlag

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -51,13 +51,6 @@ var (
 	disabledChecksFlag []string
 	// outputFormatFlag contains the output format the user has specified: default, yaml or json.
 	outputFormatFlag string
-	// TODO(komish): The description of this would imply that it's important. We generally
-	// allow users to set overrides using the --set flag. The compiler says it's unused, so something doesn't
-	// quite align. For now, we'll ignore this.
-	// setOverridesFlag contains the overrides the user has specified through the --set flag.
-	//
-	//nolint:unused,deadcode
-	setOverridesFlag []string
 	// openshiftVersionFlag set the value of `certifiedOpenShiftVersions` in the report
 	openshiftVersionFlag string
 	// write report to file


### PR DESCRIPTION
Removing unused variable. [This](https://github.com/redhat-certification/chart-verifier/commit/3f00873be5e34fa1f5749b2eada90d3784fa57ba) commit switched the relevant variable and didn't remove it's initialization.

Closes #322 