### PR TITLE
add starting dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      k8s:
+        applies-to: "version-updates"
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          - "helm.sh/*"
+          - "github.com/helm/*"
+  - package-ecosystem: github-actions
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
Dropping in a starting dependabot configuration. Note that the scripts directory ("pip" package-ecosystem) is not included as I'm currently evaluating a switch to go-based testing. If I decide not to go that route, I'll add in the pip ecosystem management to this configuration in a future PR.