### PR TITLE
Manually manage k8s dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      k8s:
-        applies-to: "version-updates"
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-          - "helm.sh/*"
-          - "github.com/helm/*"
+    ignore:
+      # Automatic updates for these are disabled as they are updated manually to
+      # align with platform dependencies defined at
+      # https://github.com/openshift/console.
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "helm.sh/*"
+      - dependency-name: "github.com/helm/*"
   - package-ecosystem: github-actions
     directory: "/.github"
     schedule:


### PR DESCRIPTION
Originally, I had these grouped to make it easier to make sure they update together - but it's probably be better if we manually manage these dependencies so we don't have to ignore them manually via dependabot on PR.