### PR TITLE
Add reusable setup-python action

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,10 @@
+name: Setup Python
+description: |
+  Consistently installs python across this project.
+  Should be used as a replacement for direct calls to actions/setup-python.
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'


### PR DESCRIPTION
This isn't called yet, but is setting up the path to be able to maintain the actions/setup-python action with a specified version in a _single_ place.

Fixes the error in executing python lint/formatting tests for https://github.com/redhat-certification/chart-verifier/pull/447