### PR TITLE
Remove additional invocation of install command

### DIFF
--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -34,7 +34,7 @@ jobs:
                 # set up python requirements and scripts on PR branch
                 python3 -m venv ve1
                 cd scripts && ../ve1/bin/pip3 install -r requirements.txt && cd ..
-                cd scripts && ../ve1/bin/pip3 install . install && cd ..
+                cd scripts && ../ve1/bin/pip3 install . && cd ..
 
             - name: Build Binary
               id: build-binary


### PR DESCRIPTION
Recent dev release actions have failed because this package was removed from PyPI and added to the prohibited packages list. This was previously being held to avoid malware incidents associated with typos (like this one), Which is why build were passing without incident before. A couple of weeks ago, the PyPI maintainers deleted the package and have locked it down for the same reasons mentioned above.