### PR TITLE
Fix bug in values merging when ci directory exists

### DIFF
--- a/internal/chartverifier/checks/charttesting.go
+++ b/internal/chartverifier/checks/charttesting.go
@@ -371,12 +371,13 @@ func newTempValuesFileWithOverrides(filename string, valuesOverrides map[string]
 
 	if filename != "" {
 		// in the case a filename is provided, read its contents and merge any available values override.
-		obj, err := readObjectFromYamlFile(filename)
+		var err error
+		obj, err = readObjectFromYamlFile(filename)
 		if err != nil {
 			return "", nil, fmt.Errorf("reading values file: %w", err)
 		}
 
-		err = mergo.MergeWithOverwrite(&obj, valuesOverrides)
+		err = mergo.Merge(&obj, valuesOverrides, mergo.WithOverride)
 		if err != nil {
 			return "", nil, fmt.Errorf("merging extra values: %w", err)
 		}


### PR DESCRIPTION
We were incorrectly assigning values contents into a transient variable where we intended to capture its value in variable assigned in one of the upper scopes. As a result, if a helm chart happened to have a ci directory (which has significance in chart-testing), then we'd end up with no values at all because we'd serialize an empty struct into a temporary values file and use that for testing.

This PR fixes that and also migrates a mergo function that's deprecated to its replacement implementation.

Fixes #465 