### PR TITLE
Remove unnecessary CI script deps

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -13,7 +13,6 @@ packaging==24.1
 parse==1.20.2
 parse-type==0.6.2
 pluggy==1.5.0
-py==1.11.0
 PyGithub==2.3.0
 pyparsing==3.1.2
 pytest==8.3.2
@@ -27,4 +26,3 @@ smmap==5.0.1
 toml==0.10.2
 urllib3==2.2.2
 six==1.16.0
-retry==0.9.2


### PR DESCRIPTION
The `Py` package is throwing an security warning on GitHub, and the `retry` package is pulling it in. Removing `retry` removes `Py`. We don't seem to use either.