### PR TITLE
Set depguard's sensitivity to reasonable defaults

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,6 +45,15 @@ linters-settings:
       - github.com/onsi/ginkgo/v2
   goimports:
     local-prefixes: github.com/redhat-certification/chart-verifier
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        files:
+          - !$test
+        allow:
+          - $gostd
 
 output:
-  format: tab
+  formats:
+  - format: tab


### PR DESCRIPTION
1. Adding depguard configurables so that it doesn't alert on every non-local import used here.
2. Adjusting the syntax of the output format declaration, which has changed (according to the schema). This just fixes a tooling warning for the moment, and prepares us for when that warning becomes an error.