### PR TITLE
Remove unneeded --no-cache option when calling podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,7 @@ test:
 # If IMAGE_TAG is not provided, use the COMMIT_ID
 .PHONY: build-image
 build-image:
-	# TODO: Adding --no-cache option as a workaround to https://github.com/containers/buildah/issues/4632
-	# This can be removed as soon as we can ensure that the ubuntu-latest runner image uses podman=>4.6.0
 	$(IMAGE_BUILDER) build \
-		--no-cache \
 		--label quay.expires-after=$(QUAY_EXPIRE_AFTER) \
 		-t $(IMAGE_REPO)/chart-verifier:$(IMAGE_TAG) .
 


### PR DESCRIPTION
According to https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md, the version of Podman used in `ubuntu-22.04` (current `ubuntu-latest`) runner image is Podman 4.9.3.