### PR TITLE
ensure we append to GITHUB_OUTPUT and require workflow parameters

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -16,8 +16,7 @@ on:
           (e.g. github.event.pull_request.number, etc.)
       checkout-repository:
         type: string
-        required: false
-        default: ""
+        required: true
         description: |
           repository flag to actions/checkout.
           
@@ -25,8 +24,7 @@ on:
           for verifying the user is a trusted user.
       checkout-ref:
         type: string
-        required: false
-        default: ""
+        required: true
         description: |
           ref flag to actions/checkout
           

--- a/.github/workflows/pr-functional-tests.yaml
+++ b/.github/workflows/pr-functional-tests.yaml
@@ -75,8 +75,8 @@ jobs:
         TEST_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       run: |
         echo "${TEST_REPO} at ${TEST_SHA} is considered ok to test."
-        echo "test-sha=${TEST_SHA}" | tee "${GITHUB_OUTPUT}"
-        echo "test-repo=${TEST_REPO}" | tee "${GITHUB_OUTPUT}"
+        echo "test-sha=${TEST_SHA}" | tee -a "${GITHUB_OUTPUT}"
+        echo "test-repo=${TEST_REPO}" | tee -a "${GITHUB_OUTPUT}"
 
   run-functional-tests:
     needs: [check-ok-to-test]


### PR DESCRIPTION
The functional test workflow would only output two of the three required outputs when determining if a PR was valid to test, causing issues in pulling down the content to be tested.