### PR TITLE
fix(verifier): return digest error when public key digest fails

### DIFF
--- a/internal/chartverifier/verifier.go
+++ b/internal/chartverifier/verifier.go
@@ -17,6 +17,7 @@
 package chartverifier
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -136,7 +137,7 @@ func (c *verifier) Verify(uri string) (*apiReport.Report, error) {
 			if len(c.publicKeys) == 1 && strings.Contains(r.Reason, checks.ChartSigned) {
 				publicKeyDigest, digestErr := tool.GetPublicKeyDigest(c.publicKeys[0])
 				if digestErr != nil {
-					return nil, err
+					return nil, fmt.Errorf("error getting public key digest: %w", digestErr)
 				}
 				result.SetPublicKeyDigest(publicKeyDigest)
 			}


### PR DESCRIPTION
Previously GetPublicKeyDigest errors were dropped and the outer verify error (which is always nil at this point) was returned instead.