### PR TITLE
Group codeql action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       - dependency-name: "helm.sh/*"
       - dependency-name: "github.com/helm/*"
   - package-ecosystem: github-actions
+    groups:
+      codeql:
+        applies-to: "version-updates"
+        patterns:
+          - "github/codeql-action*"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot-generated PRs seem to be failing, and the reason may be because the various steps have different versions