### PR TITLE
Apply new python lint rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,5 @@
 lint.ignore = [
-    "E203" # https://github.com/PyCQA/pycodestyle/issues/373
+    "E203",   # https://github.com/PyCQA/pycodestyle/issues/373
+    "FLY002", # no need to prefer fstring over string joining
+    "TRY201", # specifying exception name is okay
 ]

--- a/scripts/src/owners/checkuser.py
+++ b/scripts/src/owners/checkuser.py
@@ -11,11 +11,12 @@ results:
     to modify them.
 """
 
-import re
 import argparse
-import requests
 import os
+import re
 import sys
+
+import requests
 import yaml
 
 try:
@@ -34,8 +35,8 @@ def verify_user(username):
     if not os.path.exists(OWNERS_FILE):
         print(f"[ERROR] {OWNERS_FILE} file does not exist.")
     else:
-        data = open(OWNERS_FILE).read()
-        out = yaml.load(data, Loader=Loader)
+        with open(OWNERS_FILE) as f:
+            out = yaml.load(f, Loader=Loader)
         if username in out["approvers"]:
             print(f"[INFO] {username} authorized")
             return True

--- a/scripts/src/release/releasebody.py
+++ b/scripts/src/release/releasebody.py
@@ -1,7 +1,7 @@
 import sys
 
 sys.path.append("./scripts/src/")
-from release import releasechecker  # noqa E402
+from release import releasechecker
 
 
 def get_release_body(version, image_name, release_info):

--- a/scripts/src/release/releasechecker.py
+++ b/scripts/src/release/releasechecker.py
@@ -24,18 +24,19 @@ results:
         PR_release_image : The name of the image from the version file from main branch.
 """
 
-import re
 import argparse
-from github import Github
 import json
 import os
+import re
+import sys
+
 import requests
 import semver
-import sys
+from github import Github
 
 sys.path.append("./scripts/src/")
 from release import tarfile_asset, releasebody  # noqa 402
-from utils import utils  # noqa 402
+from utils import utils
 
 VERSION_FILE = "pkg/chartverifier/version/version_info.json"
 

--- a/scripts/src/release/tarfile_asset.py
+++ b/scripts/src/release/tarfile_asset.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import tarfile
+
 from utils import utils
 
 tar_content_files = [{"name": "out/chart-verifier", "arc_name": "chart-verifier"}]

--- a/scripts/src/saforcharttesting/saforcharttesting.py
+++ b/scripts/src/saforcharttesting/saforcharttesting.py
@@ -132,7 +132,9 @@ def apply_config(tmpl, **values):
         config_path = os.path.join(tmpdir, "config.yaml")
         with open(config_path, "w") as fd:
             fd.write(content)
-        out = subprocess.run(["oc", "apply", "-f", config_path], capture_output=True)
+        out = subprocess.run(
+            ["oc", "apply", "-f", config_path], capture_output=True, check=False
+        )
         stdout = out.stdout.decode("utf-8")
         if out.returncode != 0:
             stderr = out.stderr.decode("utf-8")
@@ -148,7 +150,9 @@ def delete_config(tmpl, **values):
         config_path = os.path.join(tmpdir, "config.yaml")
         with open(config_path, "w") as fd:
             fd.write(content)
-        out = subprocess.run(["oc", "delete", "-f", config_path], capture_output=True)
+        out = subprocess.run(
+            ["oc", "delete", "-f", config_path], capture_output=True, check=False
+        )
         stdout = out.stdout.decode("utf-8")
         if out.returncode != 0:
             stderr = out.stderr.decode("utf-8")
@@ -253,6 +257,7 @@ def write_sa_token(namespace, token_file):
         out = subprocess.run(
             ["oc", "get", "secret", namespace, "-n", namespace, "-o", "json"],
             capture_output=True,
+            check=False,
         )
         stdout = out.stdout.decode("utf-8")
         if out.returncode != 0:
@@ -282,17 +287,24 @@ def write_sa_token(namespace, token_file):
 
 
 def switch_project_context(namespace, token, api_server):
-    tkn = open(token).read()
+    with open(token) as f:
+        tkn = f.read()
     for i in range(7):
         out = subprocess.run(
-            ["oc", "login", "--token", tkn, "--server", api_server], capture_output=True
+            ["oc", "login", "--token", tkn, "--server", api_server],
+            capture_output=True,
+            check=False,
         )
         stdout = out.stdout.decode("utf-8")
         print(stdout)
-        out = subprocess.run(["oc", "project", namespace], capture_output=True)
+        out = subprocess.run(
+            ["oc", "project", namespace], capture_output=True, check=False
+        )
         stdout = out.stdout.decode("utf-8")
         print(stdout)
-        out = subprocess.run(["oc", "config", "current-context"], capture_output=True)
+        out = subprocess.run(
+            ["oc", "config", "current-context"], capture_output=True, check=False
+        )
         stdout = out.stdout.decode("utf-8").strip()
         print(stdout)
         if stdout.endswith(":".join((namespace, namespace))):

--- a/tests/tests/functional/chart_test.py
+++ b/tests/tests/functional/chart_test.py
@@ -8,15 +8,15 @@ Following environment variables are expected to be set in order to run the tests
               deploy the charts on.
 """
 
-from pytest_bdd import scenario, given, when, then, parsers
+import json
 import os
 import subprocess
-import pytest
-import json
 import tarfile
-from deepdiff import DeepDiff
 
+import pytest
 import yaml
+from deepdiff import DeepDiff
+from pytest_bdd import given, parsers, scenario, then, when
 
 try:
     from yaml import CLoader as Loader
@@ -196,10 +196,12 @@ def run_verifier(
 
 
 def run_version_tarball_image(tarball_name):
-    tar = tarfile.open(tarball_name, "r:gz")
-    tar.extractall(path="./test_verifier")
+    with tarfile.open(tarball_name, "r:gz") as tar:
+        tar.extractall(path="./test_verifier")
     out = subprocess.run(
-        ["./test_verifier/chart-verifier", "version", "--as-data"], capture_output=True
+        ["./test_verifier/chart-verifier", "version", "--as-data"],
+        capture_output=True,
+        check=False,
     )
     return normalize_version(out.stdout.decode("utf-8"))
 
@@ -230,6 +232,7 @@ def run_version_podman_image(verifier_image_name, verifier_image_tag):
             "--as-data",
         ],
         capture_output=True,
+        check=False,
     )
     return normalize_version(out.stdout.decode("utf-8"))
 
@@ -239,9 +242,8 @@ def run_verify_tarball_image(
 ):
     print(f"Run tarball image from {tarball_name}")
 
-    tar = tarfile.open(tarball_name, "r:gz")
-
-    tar.extractall(path="./test_verifier")
+    with tarfile.open(tarball_name, "r:gz") as tar:
+        tar.extractall(path="./test_verifier")
 
     if pgp_key_location:
         out = subprocess.run(
@@ -255,6 +257,7 @@ def run_verify_tarball_image(
                 chart_location,
             ],
             capture_output=True,
+            check=False,
         )
     else:
         out = subprocess.run(
@@ -266,6 +269,7 @@ def run_verify_tarball_image(
                 chart_location,
             ],
             capture_output=True,
+            check=False,
         )
 
     return out.stdout.decode("utf-8")
@@ -274,9 +278,8 @@ def run_verify_tarball_image(
 def run_report_tarball_image(tarball_name, profile_type, chart_location):
     print(f"Run tarball image from {tarball_name}")
 
-    tar = tarfile.open(tarball_name, "r:gz")
-
-    tar.extractall(path="./test_verifier")
+    with tarfile.open(tarball_name, "r:gz") as tar:
+        tar.extractall(path="./test_verifier")
 
     out = subprocess.run(
         [
@@ -288,6 +291,7 @@ def run_report_tarball_image(tarball_name, profile_type, chart_location):
             chart_location,
         ],
         capture_output=True,
+        check=False,
     )
 
     return out.stdout.decode("utf-8")
@@ -305,7 +309,7 @@ def run_verify_podman_image(
     if not kubeconfig:
         return "FAIL: missing KUBECONFIG environment variable"
 
-    if chart_location.startswith("http:/") or chart_location.startswith("https:/"):
+    if chart_location.startswith(("http:/", "https:/")):
         if pgp_key_location:
             out = subprocess.run(
                 [
@@ -325,6 +329,7 @@ def run_verify_podman_image(
                     chart_location,
                 ],
                 capture_output=True,
+                check=False,
             )
         else:
             out = subprocess.run(
@@ -343,6 +348,7 @@ def run_verify_podman_image(
                     chart_location,
                 ],
                 capture_output=True,
+                check=False,
             )
     else:
         chart_directory = os.path.dirname(os.path.abspath(chart_location))
@@ -369,6 +375,7 @@ def run_verify_podman_image(
                     f"/charts/{chart_name}",
                 ],
                 capture_output=True,
+                check=False,
             )
         else:
             out = subprocess.run(
@@ -389,6 +396,7 @@ def run_verify_podman_image(
                     f"/charts/{chart_name}",
                 ],
                 capture_output=True,
+                check=False,
             )
 
     return out.stdout.decode("utf-8")
@@ -416,6 +424,7 @@ def run_report_podman_image(
             f"/reports/{report_name}",
         ],
         capture_output=True,
+        check=False,
     )
 
     return out.stdout.decode("utf-8")
@@ -504,10 +513,8 @@ def check_report(
     with open(report_path, "w") as fd:
         fd.write(verify_result)
 
-    expected_reports_file = open(
-        report_info_location,
-    )
-    expected_reports = json.load(expected_reports_file)
+    with open(report_info_location) as expected_reports_file:
+        expected_reports = json.load(expected_reports_file)
 
     test_report_data = run_report(image_type, profile_type, report_path)
     print(f"test_report_data : \n{test_report_data}")
@@ -547,15 +554,17 @@ def check_report(
         "charts.openshift.io/testedOpenShiftVersion",
     }
 
-    for annotation in expected_annotations.keys():
-        if annotation not in differing_annotations:
-            if expected_annotations[annotation] != tested_annotations[annotation]:
-                test_passed = False
-                print(
-                    f"{annotation} has different content, "
-                    f"expected: {expected_annotations[annotation]}, "
-                    f"got: {tested_annotations[annotation]}"
-                )
+    for annotation, expected_value in expected_annotations.items():
+        if (
+            annotation not in differing_annotations
+            and expected_value != tested_annotations[annotation]
+        ):
+            test_passed = False
+            print(
+                f"{annotation} has different content, "
+                f"expected: {expected_value}, "
+                f"got: {tested_annotations[annotation]}"
+            )
 
     digests_diff = DeepDiff(
         expected_reports[REPORT_DIGESTS], test_report[REPORT_DIGESTS], ignore_order=True
@@ -567,7 +576,7 @@ def check_report(
     differing_metadata = {"chart-uri"}
     expected_metadata = expected_reports[REPORT_METADATA]
     test_metadata = test_report[REPORT_METADATA]
-    for metadata in expected_metadata.keys():
+    for metadata in expected_metadata:
         if metadata not in differing_metadata:
             metadata_diff = DeepDiff(
                 expected_metadata[metadata], test_metadata[metadata], ignore_order=True


### PR DESCRIPTION
Addresses issues with ruff after an assumed version update. Most make sense, a couple do not, so those have been excluded.