### PR TITLE
Update actions/checkout to v7.0.1.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
 
         steps:
             - name: Checkout changes
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 persist-credentials: false
             - name: Setup Go

--- a/.github/workflows/check-actions.yml
+++ b/.github/workflows/check-actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -47,7 +47,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/dev_release.yaml
+++ b/.github/workflows/dev_release.yaml
@@ -22,7 +22,7 @@ jobs:
           contents: write
         steps:
             - name: Checkout code
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
                 persist-credentials: false
 

--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -1,8 +1,12 @@
 name: Run Functional Tests
 
 # Runs functional testing against the specified checkout-ref.
-# Note that this workflow runs and installs software from the checkout-ref, 
-# and so untrusted content should be verified as safe to install
+# Note that this workflow runs and installs software from the checkout-ref,
+# and so untrusted content should be verified as safe to install.
+#
+# This workflow does not gate untrusted content itself. Callers must verify
+# that the checkout-ref and checkout-repository inputs point to acceptable
+# content before invoking this workflow.
 
 on:
   workflow_call:
@@ -33,6 +37,17 @@ on:
 
           For security, this checkout-ref should generally be a commit hash
           for untrusted content.
+      allow-unsafe-pr-checkout:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether actions/checkout should allow an unsafe checkout of
+          checkout-ref and checkout-repository.
+
+          Enable only when the checkout-ref and/or checkout-repository
+          content has been evaluated and is safe to checkout in a workflow
+          with privileged context.
     secrets:
       # TODO: Refactor cluster-api-server as it's not actually a secret but must
       # be because it's listed in-repo as a secret.
@@ -51,11 +66,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout-ref }}
           repository: ${{ inputs.checkout-repository }}
           persist-credentials: false
+          # This workflow does not gate untrusted content itself. Callers
+          # must verify that the checkout-ref and checkout-repository inputs
+          # point to acceptable content before invoking this workflow.
+          allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
 
       # TODO: May be worth caching this binary, given there are several places
       # that build the binary in workflows. For now, just build this to allow

--- a/.github/workflows/golang-style.yml
+++ b/.github/workflows/golang-style.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         contents: read
       steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-functional-tests.yaml
+++ b/.github/workflows/pr-functional-tests.yaml
@@ -87,6 +87,8 @@ jobs:
     with:
       checkout-repository: ${{ needs.check-ok-to-test.outputs.target-repo }}
       checkout-ref: ${{ needs.check-ok-to-test.outputs.target-sha }}
+      # Gated by ok-to-test label, which requires a maintainer to apply.
+      allow-unsafe-pr-checkout: true
       event-identifier: ${{ github.event.pull_request.number }}
     secrets:
       cluster-api-server: ${{ secrets.API_SERVER }}
@@ -102,7 +104,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -124,13 +126,16 @@ jobs:
           # check for a restricted file and, if found, check user has permission
           ve1/bin/check-user --api-url="${API_URL}" --user="${API_USER}"
 
+      # Gated by the ok-to-test label (check-ok-to-test job) and the
+      # check-user authorization step above (check_authorization).
       - name: Checkout PR branch # untrusted content!
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: "chart-verifier"
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       # TODO: May be worth caching this binary, given there are several places
       # that build the binary in workflows. For now, just build this to allow

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/scan-branch-sbom.yaml
+++ b/.github/workflows/scan-branch-sbom.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Generate SBOM


### PR DESCRIPTION
In this upgrade, we have to make sure we're explicitly allowing unsafe checkouts for specific cases where we need to run tests in a privileged context. Cases that need the override have had it added, and have it documented that callers should be gating appropriately before doing so.