### PR TITLE
Support redhat-actions/push-to-registry@v3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,22 +34,24 @@ jobs:
         id: build_container_images
         env:
           COMMIT_ID: ${{ steps.get_commit_id.outputs.commit_id }}
+        # Build images using an explicit localhost registry reference.
+        # Rely on the push operation to map it to the right remote.
         run: |
             podman version
-            # Build podman images locally
-            make build-image "IMAGE_TAG=${COMMIT_ID}" QUAY_EXPIRE_AFTER=1w
-            make build-image IMAGE_TAG=main
-            podman tag "${CONTAINER_REGISTRY}/chart-verifier:main" "${CONTAINER_REGISTRY}/chart-verifier:${DEV_RELEASE}"
+            make build-image "IMAGE_TAG=${COMMIT_ID}" IMAGE_REPO=localhost QUAY_EXPIRE_AFTER=1w
+            make build-image IMAGE_TAG=main IMAGE_REPO=localhost
+            podman tag "localhost/chart-verifier:main" "localhost/chart-verifier:${DEV_RELEASE}"
 
       - name: Push to quay.io
         id: push_to_quay
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 # v3.0.0
         with:
+          # Automatically prepended with localhost/ as the registry.
           image: chart-verifier
           tags: |
             ${{ steps.get_commit_id.outputs.commit_id }}
             main
             ${{ env.DEV_RELEASE }}
-          registry: quay.io/redhat-certification
+          registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ secrets.QUAY_BOT_USERNAME }}
           password: ${{ secrets.QUAY_BOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,15 +137,16 @@ jobs:
           RELEASE_VERSION: ${{ steps.get_tag.outputs.release_version }}
         run: |
             # Build podman images locally
-            make build-image "IMAGE_TAG=${RELEASE_VERSION}" "IMAGE_REPO=${{ secrets.IMAGE_REGISTRY }}"
+            make build-image "IMAGE_TAG=${RELEASE_VERSION}" IMAGE_REPO=localhost
             podman tag \
-              "${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}:${RELEASE_VERSION}" \
-              "${{ secrets.IMAGE_REGISTRY }}/${IMAGE_NAME}:latest"
+              "localhost/${IMAGE_NAME}:${RELEASE_VERSION}" \
+              "localhost/${IMAGE_NAME}:latest"
 
       - name: Push to quay.io
         id: push_to_quay
-        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 # v3.0.0
         with:
+          # Prepended with localhost by the action to match build_container_images step.
           image: ${{ env.IMAGE_NAME }}
           tags: |
             latest


### PR DESCRIPTION
The push-to-registry step implemented a feature where the provided image name is automatically prepended with "localhost" as the registry to avoid ambiguity in the pushed image. Historically it would simply use the provided image name (e.g. chart-verifier) which worked for us. Other users reported that podman would push the wrong image in cases where there are multiple images (i.e. a fully qualified and unqualified image) with the same name.

This patch forces the build steps to explicitly build using localhost as the registry which should comply with the new expectations. This should also prevent the issue stated above, which may still occur if we use a fully qualified name and pull an image at some point after we build the image. This is not a case we have currently, but this approach should be safer overall.

Closes #659 